### PR TITLE
Update documentation of feedit feature

### DIFF
--- a/Documentation/UserTsconfig/admPanel/Index.rst
+++ b/Documentation/UserTsconfig/admPanel/Index.rst
@@ -108,8 +108,6 @@ Configuration of the Admin Panel in the Frontend for the user.
 
          .edit.displayIcons (boolean)
 
-         .edit.editFormsOnPage (boolean)
-
          .edit.editNoPopup (boolean)
 
          .tsdebug.forceTemplateParsing (boolean)


### PR DESCRIPTION
The option `editFormsOnPage` was removed in 6.2 and did not work properly before.
See: https://forge.typo3.org/projects/typo3cms-core/repository/revisions/545610af1285629e8355aa6e1f7bdd06b4941026
