### PR TITLE
 Improve description of mod.SHARED.colPos_list

### DIFF
--- a/Documentation/PageTsconfig/Mod/Index.rst
+++ b/Documentation/PageTsconfig/Mod/Index.rst
@@ -420,10 +420,15 @@ Shared options for modules (mod.SHARED)
          However most websites use only the Normal column, maybe another also.
          In that case the remaining columns are not needed. By this option you
          can specify exactly which of the columns you want to display.
+         
+         If used on top of Backend Layouts, this setting controls which colums
+         are editabel. Columns configured in the Backend Layout which are not
+         listed here, will be displayed with placeholder area.
 
          Each column has a number which ultimately comes from the configuration
          of the table tt\_content, field 'colPos' found in the tables.php file.
-         These are the values of the four default columns:
+         These are the values of the four default columns in the default Backend
+         Layout:
 
          Left: 1
 
@@ -443,8 +448,9 @@ Shared options for modules (mod.SHARED)
 
          .. note::
 
-            Since TYPO3 6.0 mod.SHARED.colPos_list is no longer working.
+            In TYPO3 CMS 6.0 and 6.1 mod.SHARED.colPos_list is no longer working.
             Instead, use backend layouts.
+            In TYPO3 CMS 6.2 LTS, this setting was reintroduced.
 
          .. _example_for_backend_layout:
 


### PR DESCRIPTION
The property colPost_list has been reintroduced to 6.2 with commits:
241f4d0e8bc6568e6d48b084291afe23f5e203cd
20de0fc46b15f783b1884b9d7823617b838c9407
6a38987010ed732a4f25587fab52a39c336526d5

It is not considered deprecated any more, but can be used on top of Backend Layouts.

Releases: master, 6.2