### PR TITLE
[TASK] Remove documentation for clearRTECache

### DIFF
--- a/Documentation/UserTsconfig/Options/Index.rst
+++ b/Documentation/UserTsconfig/Options/Index.rst
@@ -116,23 +116,6 @@ Various options for the user affecting the core at various points.
    Default
          0
 
-
-.. container:: table-row
-
-   Property
-         clearCache.clearRTECache
-
-   Data type
-         boolean
-
-   Description
-         If set, the option «Clear RTE Cache» is enabled in the Clear Cache
-         menu. Note that the option is always available to admin users.
-
-   Default
-         0
-
-
 .. container:: table-row
 
    Property


### PR DESCRIPTION
options.clearCache.clearRTECache was removed from TYPO3 CMS 6.1
with https://review.typo3.org/12912

options.clearCache.clearLangCache was removed from TYPO3 CMS 6.2
with https://review.typo3.org/24077