### PR TITLE
[TASK] Replace documentation for clearRTECache with clearLangCache

### DIFF
--- a/Documentation/UserTsconfig/Options/Index.rst
+++ b/Documentation/UserTsconfig/Options/Index.rst
@@ -76,7 +76,7 @@ Various options for the user affecting the core at various points.
 .. container:: table-row
 
    Property
-         clearCache.clearRTECache
+         clearCache.clearLangCache
 
    Data type
          boolean


### PR DESCRIPTION
options.clearCache.clearRTECache was replaced by
options.clearCache.clearLangCache in TYPO3 CMS 6.1
with https://review.typo3.org/12912