### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/UserTsconfig/Options/Index.rst
+++ b/Documentation/UserTsconfig/Options/Index.rst
@@ -81,7 +81,7 @@ Various options for the user affecting the core at various points.
          boolean
 
    Description
-         This will allow a non-admin user to clear frontend and page-related caches.
+         This will allow a non-admin user to clear frontend caches.
 
    Default
          0
@@ -95,7 +95,7 @@ Various options for the user affecting the core at various points.
          boolean
 
    Description
-         This will allow a non-admin user to clear frontend and page-related caches, plus some
+         This will allow a non-admin user to clear frontend caches, plus some
          backend-related caches (that is everything including templates). This property is equivalent to clearCache.all.
 
    Default
@@ -110,7 +110,7 @@ Various options for the user affecting the core at various points.
          boolean
 
    Description
-         This will allow a non-admin user to clear frontend and page-related caches, plus some
+         This will allow a non-admin user to clear frontend caches, plus some
          backend-related caches (that is everything including templates).
 
    Default


### PR DESCRIPTION
I was wondering why my editors are able to clear caches for single pages while options.clearCache.pages were set to "0". The documentation speaks about "page-related caches" – so I expected the editors weren't able to clear the cache for a single page by default. I guess "page-related" has to be removed. Or do I misunderstand the term?