### PR TITLE
[TASK] Remove mod.web_layout.tt_content.fieldOrder

### DIFF
--- a/Documentation/PageTsconfig/Mod/Index.rst
+++ b/Documentation/PageTsconfig/Mod/Index.rst
@@ -612,32 +612,6 @@ Web > Page (mod.web\_layout)
 			mod.web_layout.tt_content.colPos_list = 0,3
 
 
-.. container:: table-row
-
-   Property
-         tt\_content.fieldOrder
-
-   Data type
-         *(list of field names from tt\_content table)*
-
-   Description
-         This allows you to specify (and thereby overrule) the preferred order
-         of the field names of the "Quick Edit" editing forms of the
-         tt\_content table (Content Elements). Just specify the list of fields,
-         separated by comma. Then these fields will be listed first and all
-         remaining fields thereafter in their original order.
-
-         **Example:**
-
-         This results in the 'Text' field and thereafter 'Header' field being
-         displayed as the very first fields instead of the 'Type' field.
-
-         .. code-block:: typoscript
-
-			mod.web_layout.tt_content {
-				fieldOrder = bodytext, header
-			}
-
 
 .. container:: table-row
 


### PR DESCRIPTION
fieldOrder was used to re-arrange specific fields in quick edit mode of the page module.
This however is mostly broken since 4.5 with all the --div-- and --palette-- containers and
only a couple of elements can be moved around successfully. This option is now removed
from documentation in 6.2 and master and will be dropped code wise in master completely.