### PR TITLE
[Task] remove moduleMenuCollapsable from doc

### DIFF
--- a/Documentation/UserTsconfig/Options/Index.rst
+++ b/Documentation/UserTsconfig/Options/Index.rst
@@ -975,21 +975,6 @@ Various options for the user affecting the core at various points.
 
          This will enable TemplaVoila page module as default page module.
 
-
-.. container:: table-row
-
-   Property
-         moduleMenuCollapsable
-
-   Data type
-         boolean
-
-   Description
-         If set, the user can collapse main modules in the left menu.
-
-   Default
-         1
-
 .. container:: table-row
 
    Property


### PR DESCRIPTION
According to https://forge.typo3.org/issues/49359 the property options.moduleMenuCollapsable has been removed a lot of time ago (since 4.5 at least)
here I remove it from documentation