### PR TITLE
[TASK] Remove value type for options.backendlayout.exclude

### DIFF
--- a/Documentation/PageTsconfig/Options/Index.rst
+++ b/Documentation/PageTsconfig/Options/Index.rst
@@ -21,12 +21,12 @@ backendLayout
          exclude
 
    Data type
-         *(list of integers)*
+         *(list of identifiers)*
 
    Description
          Excludes a list of backend layouts form being usable during assigning a layout in the backend.
 
-         Use the uid of the record in the default data provider.
+         Use the uid/identifier of the record in the default data provider.
 
          **Example:**
 


### PR DESCRIPTION
As backendLayout's aren't not only saved in DB, the so called uid can also be a string like `pagets__Default`.