### PR TITLE
document current behavior of clearCache.alll

### DIFF
--- a/Documentation/UserTsconfig/Options/Index.rst
+++ b/Documentation/UserTsconfig/Options/Index.rst
@@ -118,6 +118,7 @@ clearCache.system
    Description
          This will allow a non-admin user to clear frontend and page-related caches, plus some
          backend-related caches (that is everything including templates). This property is equivalent to clearCache.all.
+         **Note:** this option has been removed on TYPO3 8.7 and above.
 
    Default
          0
@@ -137,7 +138,8 @@ clearCache.all
 
    Description
          This will allow a non-admin user to clear frontend and page-related caches, plus some
-         backend-related caches (that is everything including templates).
+         backend-related caches (that is everything including templates); if it is explicitly set to 0 for an admin user,
+         it will remove the clear all option on toolbar for that user.
 
    Default
          0


### PR DESCRIPTION
I added the effect of `options.clearCache.alll = 0` on an admin user
Related issue: https://forge.typo3.org/issues/82510

I also added a note on `clearCache.system`; please consider removing the whole option for 8.7 and master documentation and keep it only for 7.6 as it seems to work only for that version (If I am not wrong).