### PR TITLE
[TASK] Document showDuplicate visibility management

### DIFF
--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -903,8 +903,8 @@ showDuplicate
 :aspect:`Description`
     If set, a button "Duplicate" will appear in TCEFORMs.
 
-    Note it is possible to set this for single tables using `options.duplicate.[tableName]`.
-    Any value set for a single table will override the default value set for "saveDocView".
+    Note that it is possible to set this for single tables using :ts:`options.duplicate.[tableName]`.
+    Any value set for a single table will override the default value set for :ts:`saveDocView`.
 
 :aspect:`Default`
     0

--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -892,6 +892,24 @@ saveDocView
     1
 
 
+.. _useroptions-showDuplicate:
+
+showDuplicate
+=============
+
+:aspect:`Datatype`
+    boolean
+
+:aspect:`Description`
+    If set, a button "Duplicate" will appear in TCEFORMs.
+
+    Note it is possible to set this for single tables using `options.duplicate.[tableName]`.
+    Any value set for a single table will override the default value set for "saveDocView".
+
+:aspect:`Default`
+    0
+
+
 .. _useroptions-showHistory:
 
 showHistory


### PR DESCRIPTION
With #84749, the Duplicate Button will be hidden per default throughout
the Backend. It can be enabled globally and refined on a per table base.