### PR TITLE
more emphasis about enabled admPanel for admin

### DIFF
--- a/Documentation/UserTsconfig/AdmPanel.rst
+++ b/Documentation/UserTsconfig/AdmPanel.rst
@@ -71,8 +71,12 @@ enable
         admPanel.enable.tsdebug
         admPanel.enable.info
 
-.. Attention::
-   For admin users, `admPanel.enable.all = 1` is default
+:aspect:`Default` 
+    For admin users, `admPanel.enable.all = 1` is default.
+
+    .. note::
+       The admin Panel is active for all admin users by default. If this does
+       not fit the necessary setup, the different modules can be disabled.
 
 
 hide

--- a/Documentation/UserTsconfig/AdmPanel.rst
+++ b/Documentation/UserTsconfig/AdmPanel.rst
@@ -71,8 +71,8 @@ enable
         admPanel.enable.tsdebug
         admPanel.enable.info
 
-:aspect:`Default`
-    For admin users, `admPanel.enable.all = 1` is default
+.. Attention::
+   For admin users, `admPanel.enable.all = 1` is default
 
 
 hide


### PR DESCRIPTION
for admin users the admPanel is enabled by default. This information needs an higher emphasis IMHO

discard this change if you think it is no good.