### PR TITLE
Correct TS configuration example to disable admin panel for users

### DIFF
--- a/Documentation/UserTsconfig/AdmPanel.rst
+++ b/Documentation/UserTsconfig/AdmPanel.rst
@@ -20,11 +20,11 @@ done by inserting this string in the TypoScript Template:
    # Note this is a frontend TypoScript template and not TSconfig!
    config.admPanel = 1
 
-Example TSconfig to disable the admin panel for a user:
+Example user TSconfig to disable the admin panel for a user:
 
 .. code-block:: typoscript
 
-   admPanel.enable = 0
+   admPanel.hide = 1
 
 .. note::
 


### PR DESCRIPTION
admPanel.enable = 0
does not disable admin panel in TYPO3 9
only
admPanel.enable.all = 0
or
admPanel.hide = 1
will end in an expected result