### PR TITLE
Improve new content element wizard examples

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -1171,7 +1171,7 @@ newContentElement.wizardItems
 
         # Add a new element (header) to the "common" group
         mod.wizards.newContentElement.wizardItems.common.elements.header {
-            iconIdentifier = content-text
+            iconIdentifier = content-header
             title = Header
             description = Adds a header element only
             tt_content_defValues {
@@ -1188,7 +1188,7 @@ newContentElement.wizardItems
         mod.wizards.newContentElement.wizardItems.myGroup {
             header = LLL:EXT:cms/layout/locallang.xlf:advancedFunctions
             elements.customText {
-                icon = gfx/c_wiz/regular_text.gif
+                iconIdentifier = content-text
                 title = Introductory text for national startpage
                 description = Use this element for all national startpages
                 tt_content_defValues {


### PR DESCRIPTION
In the first example the option _iconIdentifier_ should have the value _content-header_ instead of _content-text_ as it is a header content element.
In the second example the option _iconIdentifier_ should be used instead of the deprecated option _icon_.