### PR TITLE
TASK: Remove overcomplicated documentation part.

### DIFF
--- a/Documentation/UsingSetting/Index.rst
+++ b/Documentation/UsingSetting/Index.rst
@@ -74,12 +74,7 @@ which they are set, and for all pages hierarchically below. You can
 overwrite and :ref:`modify <t3coreapi:typoscript-syntax-syntax-value-modification>` them
 in the Page TSconfig of the same page or a subpage.
 
-Page TSconfig itself can be overwritten by User TSconfig.
-
-.. important::
-
-   It is *not* possible to *modify* Page TSconfig in User TSconfig. Page TSconfig can only be
-   :ref:`overwritten in User TSconfig <userrelationshiptovaluessetinpagetsconfig>`.
+Page TSconfig itself can be :ref:`overwritten in User TSconfig <userrelationshiptovaluessetinpagetsconfig>`.
 
 
 **Example:**


### PR DESCRIPTION
Keep reference to detail information. The removed information is already
mentioned there, in an easier to understand way.