### PR TITLE
Use the preferred extension for PageTS files

### DIFF
--- a/Documentation/UsingSetting/Index.rst
+++ b/Documentation/UsingSetting/Index.rst
@@ -136,7 +136,7 @@ which will be shown in the page properties (the same way as TypoScript static te
 
    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
       'extension_name',
-      'Configuration/TSconfig/Page/myPageTSconfigFile.txt',
+      'Configuration/TSconfig/Page/myPageTSconfigFile.tsconfig',
       'My special config'
    );
 


### PR DESCRIPTION
The preferred extension for PageTS files is .tsconfig, not .txt anymore.