### PR TITLE
Document TCEMAIN.preview.disableButtonForDokType

### DIFF
--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -334,6 +334,7 @@ preview
         TCEMAIN.preview {
             <table name> {
                 previewPageId = 123
+                disableButtonForDokType = 199, 254, 255
                 useDefaultLanguageRecord = 0
                 fieldToParameterMap {
                     uid = tx_myext_pi1[showUid]
@@ -347,6 +348,9 @@ preview
 
     The :ts:`previewPageId` is the uid of the page to use for preview. If this setting is omitted the
     current page will be used. If the current page is not a normal page, the root page will be chosen.
+    
+    The :ts:`disableButtonForDokType` setting allows you to disable the preview button for a given list 
+    of doktypes. If none are configured, this defaults to: 199, 254, 255 (Spacer, Folder and Recycler).
 
     The :ts:`useDefaultLanguageRecord` defaults to `1` and ensures that translated records will use the
     uid of the default record for the preview link. You may disable this, if your extension can deal


### PR DESCRIPTION
Document TCEMAIN.preview.disableButtonForDokType (which is there since TYPO3 7.6).