### PR TITLE
Fix block quotes

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -98,7 +98,6 @@ defaultLanguageFlag
         The flag selector of a language record in the backend
 
 :aspect:`Example`
-
     This will show the German flag, and the text "deutsch" on hover.
 
     .. code-block:: typoscript
@@ -162,7 +161,6 @@ fieldDefinitions
     The string `###ALL_TABLES###` is replaced with a list of all table names an editor has access to.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_info.fieldDefinitions {
@@ -210,7 +208,6 @@ menu.function
         option of blinding elements mostly to remove otherwise distracting options.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_info.menu.function {
@@ -249,7 +246,6 @@ allowInconsistentLanguageHandling
     If you want to go back to the old, inconsistent behavior, you can toggle it back on via this switch.
 
 :aspect:`Example`
-
     Allows to set TYPO3s page module back to inconsistent language mode
 
     .. code-block:: typoscript
@@ -267,7 +263,6 @@ BackendLayouts
     Allows to define backend layouts via Page TSconfig directly without using database records.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_layout.BackendLayouts {
@@ -400,7 +395,6 @@ editFieldsAtATime
     1
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_layout {
@@ -549,8 +543,8 @@ preview
 
     .. note::
 
-        This only works, if there is no hook registered for this content type, you may want to check this
-        section in the "System > Configuration" module:
+       This only works, if there is no hook registered for this content type, you may want to check this
+       section in the "System > Configuration" module:
 
        .. code-block:: php
 
@@ -558,7 +552,6 @@ preview
               ['tt_content_drawItem']['content_element_xy'];
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_layout.tt_content.preview.custom_ce = EXT:site_mysite/Resources/Private/Templates/Preview/CustomCe.html
@@ -588,13 +581,12 @@ allowedNewTables
 
     This is the opposite of :ref:`deniedNewTables property <pageTsConfigWebListDeniedNewTables>`.
 
-        .. note::
+    .. note::
 
-            Technically records can be created (e.g. by copying/moving), so this is not a security feature.
-            The point is to reduce the number of options for new records visually.
+       Technically records can be created (e.g. by copying/moving), so this is not a security feature.
+       The point is to reduce the number of options for new records visually.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list {
@@ -645,7 +637,6 @@ csvDelimiter
     ,
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list {
@@ -690,7 +681,6 @@ deniedNewTables
     If `allowedNewTables` and `deniedNewTables` contain a common subset, `deniedNewTables` takes precedence.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list {
@@ -805,7 +795,6 @@ hideTranslations
     single table names as comma-separated list.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list.hideTranslations = *
@@ -855,7 +844,6 @@ listOnlyInSingleTableView
     very practical for pages containing many records from many tables!
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list {
@@ -884,7 +872,6 @@ newContentElementWizard.override
     new content elements.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.newContentElementWizard.override = my_custom_module
@@ -915,7 +902,6 @@ noCreateRecordsLink
     0
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list {
@@ -951,7 +937,6 @@ noExportRecordsLinks
     0
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list {
@@ -983,7 +968,6 @@ table.[tableName].hideTable
     even if table name is listed in "hideTables" list.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list.table.tt_content.hideTable = 1
@@ -1001,7 +985,6 @@ tableDisplayOrder
     The keywords `before` and `after` can be used to specify an order relative to other table names.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_list.tableDisplayOrder.<tableName> {
@@ -1076,7 +1059,6 @@ menu.function
         option of blinding elements mostly to remove otherwise distracting options.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         # Disable the item "Template Analyzer"
@@ -1115,7 +1097,6 @@ previewFrameWidths
         Height of the preset
 
 :aspect:`Example`
-
     With this configuration a new preset '1014' with size 1027x768 will be configured with a label
     loaded from an xlf file and the category 'desktop'.
 
@@ -1144,7 +1125,6 @@ type
     Enter the value of the &type parameter passed to the webpage.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.web_view {
@@ -1312,7 +1292,6 @@ newRecord.pages
         Show or hide the link to create new pages at a selected position.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         mod.wizards.newRecord.pages.show {

--- a/Documentation/PageTsconfig/Options.rst
+++ b/Documentation/PageTsconfig/Options.rst
@@ -27,7 +27,6 @@ exclude
     Use the uid/identifier of the record in the default data provider.
 
 :aspect:`Example`
-
     .. figure:: ../Images/BackendLayoutID.png
         :alt: Two backend layout records shown in list module
 

--- a/Documentation/PageTsconfig/TcaDefaults.rst
+++ b/Documentation/PageTsconfig/TcaDefaults.rst
@@ -26,7 +26,7 @@ values when creating new records in the backend is this:
 
 Example:
 
-    .. code-block:: typoscript
+.. code-block:: typoscript
 
-        # Show newly created pages by default
-        TCAdefaults.pages.hidden = 0
+    # Show newly created pages by default
+    TCAdefaults.pages.hidden = 0

--- a/Documentation/PageTsconfig/TceForm.rst
+++ b/Documentation/PageTsconfig/TceForm.rst
@@ -114,7 +114,6 @@ altLabels
         Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-
    ::
 
         TCEFORM.pages.doktype {
@@ -420,7 +419,6 @@ noMatchingValue_label
         Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-
     .. code-block:: typoscript
 
         TCEFORM.pages.doktype {

--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -83,7 +83,6 @@ bookmarkGroups
    default) or "string" to change the label accordingly.
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       bookmarkGroups {
@@ -187,7 +186,6 @@ contextMenu disableItems
    options become available: `exportT3d` and `importT3d`
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       # Remove "New" and "Create New wizard" for pages context menu (list module)
@@ -231,7 +229,6 @@ defaultUploadFolder
    The syntax is "storage_uid:file_path".
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       options.defaultUploadFolder = 2:user_folders/my_folder/
@@ -261,7 +258,6 @@ dontMountAdminMounts
    boolean
 
 :aspect:`Description`
-
    This options prevents the root to be mounted for an admin user.
 
    .. note::
@@ -452,7 +448,6 @@ folderTree.altElementBrowserMountPoints
    The alternative filemounts are added to the existing filemounts.
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       options.folderTree.altElementBrowserMountPoints = _temp_/, 2:/templates, 1:/files/images
@@ -507,7 +502,6 @@ hideModules.[moduleGroup]
    *SYSTEM -> Configuration -> $GLOBALS['TBE_MODULES'] (BE Modules)*
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       # Hide module groups "file" and "help"
@@ -542,7 +536,6 @@ hideRecords.pages
    - New record wizard
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       options.hideRecords.pages = 12,45
@@ -581,7 +574,6 @@ lockToIP
       This option is only enabled if the :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['enabledBeUserIPLock']` configuration is true.
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       # Allow all from 192.168-network
@@ -636,7 +628,6 @@ overridePageModule
       and can be achieved using :ref:`hideModules <useroptions-hideModules>`, too.
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       # Enable TemplaVoila page module as default page module.
@@ -664,8 +655,7 @@ pageTree.altElementBrowserMountPoints
    unless you use the ``altElementBrowserMountPoints.append`` option
    described below.
 
-   **Example**
-
+:aspect:`Example`
    .. code-block:: typoscript
 
       options.pageTree.altElementBrowserMountPoints = 34,123
@@ -686,7 +676,6 @@ pageTree.altElementBrowserMountPoints.append
    existing UserTSconfig option.
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       options.pageTree.altElementBrowserMountPoints = 34,123
@@ -824,7 +813,6 @@ saveClipboard
    boolean
 
 :aspect:`Description`
-
    If set, the clipboard content will be preserved for the next login.
    Normally the clipboard content lasts only during the session.
 
@@ -847,7 +835,6 @@ saveDocNew
    1
 
 :aspect:`Example`
-
    In this example the button is disabled for all tables, except
    tt\_content where it will appear, and in addition create the records
    in the top of the page (default is after instead of top).
@@ -926,7 +913,6 @@ view.languageOrder
    their translation when they click the view-links.
 
 :aspect:`Example`
-
    .. code-block:: typoscript
 
       options.view.languageOrder = 2,1

--- a/Documentation/UserTsconfig/Page.rst
+++ b/Documentation/UserTsconfig/Page.rst
@@ -10,7 +10,6 @@ in the :ref:`Using and setting <useroverwritingandmodifyingvalues>` section.
 
 Example:
 
-    .. code-block:: typoscript
+.. code-block:: typoscript
 
-        page.TCEMAIN.table.pages.disablePrependAtCopy = 1
-
+    page.TCEMAIN.table.pages.disablePrependAtCopy = 1

--- a/Documentation/UserTsconfig/TcaDefaults.rst
+++ b/Documentation/UserTsconfig/TcaDefaults.rst
@@ -36,27 +36,27 @@ So these values will be authoritative if the user has no access to the field any
 
 Example:
 
-    .. code-block:: typoscript
+.. code-block:: typoscript
 
-        # Show newly created pages by default
-        TCAdefaults.pages.hidden = 0
+    # Show newly created pages by default
+    TCAdefaults.pages.hidden = 0
 
-    .. important::
+.. important::
 
-        This example will not work when creating the page from the context menu
-        since this is triggered by the values listed in the `ctrl` section of
-        :file:`typo3/sysext/core/Configuration/TCA/pages.php`::
+    This example will not work when creating the page from the context menu
+    since this is triggered by the values listed in the `ctrl` section of
+    :file:`typo3/sysext/core/Configuration/TCA/pages.php`::
 
-            'ctrl' => [
-                'useColumnsForDefaultValues' => 'doktype,fe_group,hidden',
-                ...
-            ]
+        'ctrl' => [
+            'useColumnsForDefaultValues' => 'doktype,fe_group,hidden',
+            ...
+        ]
 
-        If 'hidden' is in the list, it gets overwritten with the "neighbor" record value (see
-        :php:`\TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::setDefaultsFromNeighborRow`)
-        and as the value is set - usually to '0' - it will not be overwritten
-        again. To make it work as expected, that value must be overridden. This
-        can be done for example in the :file:`Configuration/TCA/Overrides` folder
-        of an extension::
+    If 'hidden' is in the list, it gets overwritten with the "neighbor" record value (see
+    :php:`\TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::setDefaultsFromNeighborRow`)
+    and as the value is set - usually to '0' - it will not be overwritten
+    again. To make it work as expected, that value must be overridden. This
+    can be done for example in the :file:`Configuration/TCA/Overrides` folder
+    of an extension::
 
-            $GLOBALS['TCA']['pages']['ctrl']['useColumnsForDefaultValues'] = 'doktype,fe_group';
+        $GLOBALS['TCA']['pages']['ctrl']['useColumnsForDefaultValues'] = 'doktype,fe_group';


### PR DESCRIPTION
Due to history indentation was used in some places.
This is rendered as block quote nowadays.
Therefore indentation is fixed when block quote is not intended.

Also some definition lists had a blank line after the definition term.