### PR TITLE
Clarify default cache clearing behavior when editing a page record

### DIFF
--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -83,7 +83,7 @@ clearCache_pageSiblingChildren
 :aspect:`Description`
     If set, then children of all siblings of a page being edited will have the page cache cleared.
 
-    Default is that when a page record is edited, the cache for itself and siblings (same level) is cleared.
+    Default is that when a page record is edited, the cache for itself, the parent, and siblings (same level) is cleared.
 
 
 .. _pagetcemaintables-disablehideatcopy:


### PR DESCRIPTION
If I understand the code in public/typo3/sysext/core/Classes/DataHandling/DataHandler.php:8847 right, the cache of the parent page is also cleared.