### PR TITLE
[TASK] Fix a spelling error

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -484,8 +484,8 @@ localization.enableTranslate
 
 .. _pageblindingfunctionmenuoptions-weblayout:
 
-menu.function
--------------
+menu.functions
+--------------
 
 :aspect:`Datatype`
     array
@@ -516,7 +516,7 @@ menu.function
     .. code-block:: typoscript
 
         # Disables "Languages" from function menu
-        mod.web_layout.menu.function {
+        mod.web_layout.menu.functions {
             2 = 0
         }
 


### PR DESCRIPTION
This is confusing and tripped me up, but for `web_layout` the actual key is `menu.functions`, for `web_info` the key is `menu_function`.