### PR TITLE
Remove User TSconfig option recursiveDelete

### DIFF
--- a/Documentation/UserTsconfig/Setup.rst
+++ b/Documentation/UserTsconfig/Setup.rst
@@ -114,16 +114,6 @@ neverHideAtCopy
     If set, then the hideAtCopy feature for records in TCE will not be used.
 
 
-recursiveDelete
-===============
-
-:aspect:`Datatype`
-    boolean
-
-:aspect:`Description`
-    Recursive Delete(!): Allow ALL subpages to be deleted when deleting a page
-
-
 resizeTextareas
 ===============
 


### PR DESCRIPTION
See: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Breaking-92560-BackendEditorsCanAlwaysDeletePagesRecursive.html

Related: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1082