### PR TITLE
Add hint about translatable labels for bookmark groups

### DIFF
--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -97,6 +97,17 @@ bookmarkGroups
    Group 5 has not been set, so it will be displayed by default, just
    like group 1.
 
+   .. versionadded:: 11.0
+
+   Custom language labels can also be used instead of a fixed label:
+
+   .. code-block:: typoscript
+
+      bookmarkGroups {
+         2 = LLL:EXT:sitepackage/Resources/Private/Language/locallang_be.xlf:bookmarkGroups.2
+      }
+
+
 
 .. _useroptions-clearCache-all:
 


### PR DESCRIPTION
See: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Feature-92337-AllowTranslatableLabelsForBookmarkGroups.html

Related: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1082