### PR TITLE
Reintroduce setting pageTree.excludeDoktypes

### DIFF
--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -799,6 +799,21 @@ pageTree.doktypesToShowInNewPageDragArea
 :aspect:`Default`
    1,6,4,7,3,254,255,199
 
+.. index:: Page tree; Exclude doktypes
+.. _useroptions-pageTree-excludeDoktypes:
+
+pageTree.excludeDoktypes
+------------------------
+:aspect:`Datatype`
+   list of integers
+
+:aspect:`Description`
+   Excludes nodes (pages) with one of the defined doktypes from the pagetree. Can be used for example for hiding custom doktypes.
+
+:aspect:`Example`
+   .. code-block:: typoscript
+
+      options.pageTree.excludeDoktypes = 254,1
 
 .. todo:: does this still work with site configuration?
 .. index:: Page tree; Show domain names


### PR DESCRIPTION
As far as I understand, this setting still works in TYPO3 11.5 LTS.

It was removed in TYPO3 Version 9:
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Breaking-82919-RemovedPageTreeRelatesTsConfigSettings.html

But it seemed to be reintroduced with this Issue?
https://forge.typo3.org/issues/87581