### PR TITLE
[DOCS] Add links to further TypoScript manuals in abstract

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -25,6 +25,13 @@ TSconfig Reference
 This document describes TSconfig: A TypoScript-like syntax for configuring
 details of the TYPO3 backend.
 
+In addition, you can find a quick reference guide to TypoScript templates in
+:doc:`t3ts45:Index`, a complete reference of all object types and properties of
+TypoScript in :doc:`TypoScript Reference <t3tsref:Index>` and explanations of
+TypoScript syntax in the chapter
+":ref:`TypoScript Syntax <t3coreapi:typoscript-syntax-start>`" of TYPO3
+Explained.
+
 ----
 
 **Table of Contents:**

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -44,7 +44,7 @@ t3tca          = https://docs.typo3.org/m/typo3/reference-tca/8.7/en-us/
 # t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
 # t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
 t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/8.7/en-us/
-# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
+t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/8.7/en-us/
 # t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
 # t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
 

--- a/README.rst
+++ b/README.rst
@@ -5,5 +5,14 @@ TSconfig Reference
 This document describes TSconfig: A TypoScript-like syntax for configuring
 details of the TYPO3 backend.
 
+In addition, you can find a quick reference guide to TypoScript templates in
+`TypoScript in 45 Minutes`_, a complete reference of all object types and
+properties of TypoScript in `TypoScript Reference`_ and explanations of
+TypoScript syntax in the chapter "`TypoScript Syntax`_" of TYPO3 Explained.
+
+.. _TypoScript in 45 Minutes: https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/8.7/en-us/Index.html
+.. _TypoScript Reference: https://docs.typo3.org/m/typo3/reference-typoscript/8.7/en-us/Index.html
+.. _TypoScript Syntax: https://docs.typo3.org/m/typo3/reference-coreapi/8.7/en-us/ApiOverview/TypoScriptSyntax/Index.html#typoscript-syntax-start
+
 :Repository:  https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TSconfig
 :Read online: https://docs.typo3.org/m/typo3/reference-tsconfig/8.7/en-us/


### PR DESCRIPTION
Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185