### PR TITLE
[TASK] Remove templating tutorial from Settings.cfg

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
 t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
 # t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
 t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
-# t3templating   = https://docs.typo3.org/m/typo3/tutorial-templating/main/en-us/
 # t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
 # t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
 t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/


### PR DESCRIPTION
As information got moved to the sitepackage tutorial