### PR TITLE
Fix formatting which resulted in blockquotes

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. !!! use 3 spaces to indent on this page
+
 .. index::
    Page TSconfig; mod
    mod
@@ -34,22 +36,22 @@ colPos_list
 -----------
 
 :aspect:`Datatype`
-    list of integers
+   list of integers
 
 :aspect:`Description`
-    This option lets you specify which columns of tt_content elements should be editable in the
-    'Columns' view of the Web > Page module.
+   This option lets you specify which columns of tt_content elements should be editable in the
+   'Columns' view of the Web > Page module.
 
-    Used on top of backend layouts, this setting controls which columns are editable. Columns configured
-    in the Backend Layout which are not listed here, will be displayed with placeholder area.
+   Used on top of backend layouts, this setting controls which columns are editable. Columns configured
+   in the Backend Layout which are not listed here, will be displayed with placeholder area.
 
-    Each column has a number which ultimately comes from the configuration of the table tt_content,
-    field 'colPos'. These are the values of the four default columns used in the default backend layout:
+   Each column has a number which ultimately comes from the configuration of the table tt_content,
+   field 'colPos'. These are the values of the four default columns used in the default backend layout:
 
-    Left: `1`, Normal: `0`, Right: `2`, Border: `3`
+   Left: `1`, Normal: `0`, Right: `2`, Border: `3`
 
 :aspect:`Default`
-    1,0,2,3
+   1,0,2,3
 
 
 :aspect:`Example`
@@ -83,14 +85,14 @@ colPos_list
       .. code-block:: typoscript
          :caption: EXT:site_package/Configuration/page.tsconfig
 
-          mod.SHARED.colPos_list = 0
+         mod.SHARED.colPos_list = 0
 
    *  The result in the page module then looks like this:
 
       .. figure:: /Images/ManualScreenshots/Page/SimpleBackendLayoutLeftNotEditable.png
-          :alt: One column not editable in a backend layout
+         :alt: One column not editable in a backend layout
 
-          One column not editable in a backend layout
+         One column not editable in a backend layout
 
 
 .. index::
@@ -102,28 +104,28 @@ defaultLanguageFlag
 -------------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Country flag shown for the "Default" language in the backend, used in Web > List and Web > Page module.
-    Values as listed in the "Select flag icon" of a language record in the backend are allowed, including
-    the value "multiple".
+   Country flag shown for the "Default" language in the backend, used in Web > List and Web > Page module.
+   Values as listed in the "Select flag icon" of a language record in the backend are allowed, including
+   the value "multiple".
 
-    .. figure:: /Images/ManualScreenshots/List/SelectFlagIcon.png
-        :alt: The flag selector of a language record in the backend
+   .. figure:: /Images/ManualScreenshots/List/SelectFlagIcon.png
+      :alt: The flag selector of a language record in the backend
 
-        The flag selector of a language record in the backend
+      The flag selector of a language record in the backend
 
 :aspect:`Example`
-    This will show the German flag, and the text "deutsch" on hover.
+   This will show the German flag, and the text "deutsch" on hover.
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.SHARED {
-           defaultLanguageFlag = de
-           defaultLanguageLabel = deutsch
-       }
+      mod.SHARED {
+         defaultLanguageFlag = de
+         defaultLanguageLabel = deutsch
+      }
 
 .. warning::
 
@@ -141,12 +143,12 @@ defaultLanguageLabel
 --------------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Alternate label for "Default" when language labels are shown in the interface.
+   Alternate label for "Default" when language labels are shown in the interface.
 
-    Used in Web > List and Web > Page module.
+   Used in Web > List and Web > Page module.
 
 .. warning::
 
@@ -164,10 +166,10 @@ disableLanguages
 ----------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Comma-separated list of language UIDs which will be disabled in the given page tree.
+   Comma-separated list of language UIDs which will be disabled in the given page tree.
 
 .. warning::
 
@@ -211,46 +213,45 @@ fieldDefinitions
 ----------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    The available fields in the "Pagetree overview" module under the Info module, by default ship with the entries
-    "Basic settings", "Record overview", and "Cache and age".
+   The available fields in the "Pagetree overview" module under the Info module, by default ship with the entries
+   "Basic settings", "Record overview", and "Cache and age".
 
-    .. figure:: /Images/ManualScreenshots/Info/PageTsModWebInfoFieldDefinitions.png
-        :alt: Default entries of Pagetree Overview
+   .. figure:: /Images/ManualScreenshots/Info/PageTsModWebInfoFieldDefinitions.png
+      :alt: Default entries of Pagetree Overview
 
-        Default entries of Pagetree Overview
+      Default entries of Pagetree Overview
 
-    By using page TsConfig it is possible to change the available fields and add additional entries to the select box.
+   By using page TsConfig it is possible to change the available fields and add additional entries to the select box.
 
-    Next to using a list of fields from the `pages` table you can add counters for records in a given table by prefixing a
-    table name with `table_` and adding it to the list of fields.
+   Next to using a list of fields from the `pages` table you can add counters for records in a given table by prefixing a
+   table name with `table_` and adding it to the list of fields.
 
-    The string `###ALL_TABLES###` is replaced with a list of all table names an editor has access to.
+   The string `###ALL_TABLES###` is replaced with a list of all table names an editor has access to.
 
 :aspect:`Example`
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
-
-       mod.web_info.fieldDefinitions {
-           0 {
-               # Basic settings
-               label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_0
-               fields = title,uid,slug,alias,starttime,endtime,fe_group,target,url,shortcut,shortcut_mode
-           }
-           1 {
-               # Record overview
-               label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_1
-               fields = title,uid,###ALL_TABLES###
-           }
-           2 {
-               # Cache and age
-               label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_2
-               fields = title,uid,table_tt_content,table_fe_users
-           }
-       }
+      mod.web_info.fieldDefinitions {
+         0 {
+            # Basic settings
+            label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_0
+            fields = title,uid,slug,alias,starttime,endtime,fe_group,target,url,shortcut,shortcut_mode
+         }
+         1 {
+            # Record overview
+            label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_1
+            fields = title,uid,###ALL_TABLES###
+         }
+         2 {
+            # Cache and age
+            label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_2
+            fields = title,uid,table_tt_content,table_fe_users
+         }
+      }
 
 
 .. index::
@@ -262,41 +263,41 @@ menu.function
 -------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    Disable elements of the "Function selector" in the document header of the module. The keys for single
-    items can be found by browsing *System > Configuration > $GLOBALS['TBE_MODULES_EXT']*.
+   Disable elements of the "Function selector" in the document header of the module. The keys for single
+   items can be found by browsing *System > Configuration > $GLOBALS['TBE_MODULES_EXT']*.
 
-    .. figure:: /Images/ManualScreenshots/Info/FunctionMenuInfoModule.png
-        :alt: The function menu of the Info module
+   .. figure:: /Images/ManualScreenshots/Info/FunctionMenuInfoModule.png
+      :alt: The function menu of the Info module
 
-        The function menu of the Info module
+      The function menu of the Info module
 
-    .. warning::
+   .. warning::
 
-        Blinding the function mMenu items is not hardcore access control! All it
-        does is hide the possibility of accessing that module functionality
-        from the interface. It might be possible for users to hack their way
-        around it and access the functionality anyways. You should use the
-        option of blinding elements mostly to remove otherwise distracting options.
+      Blinding the function mMenu items is not hardcore access control! All it
+      does is hide the possibility of accessing that module functionality
+      from the interface. It might be possible for users to hack their way
+      around it and access the functionality anyways. You should use the
+      option of blinding elements mostly to remove otherwise distracting options.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-        mod.web_info.menu.function {
-            # Disable item "Page Tsconfig"
-            TYPO3\CMS\Info\Controller\InfoPageTyposcriptConfigController = 0
-            # Disable item "Log"
-            TYPO3\CMS\Belog\Module\BackendLogModuleBootstrap = 0
-            # Disable item "Pagetree Overview"
-            TYPO3\CMS\Info\Controller\PageInformationController = 0
-            # Disable item "Localization Overview"
-            TYPO3\CMS\Info\Controller\TranslationStatusController = 0
-            # Disable item "Linkvalidator"
-            TYPO3\CMS\Linkvalidator\Report\LinkValidatorReport = 0
-        }
+      mod.web_info.menu.function {
+         # Disable item "Page Tsconfig"
+         TYPO3\CMS\Info\Controller\InfoPageTyposcriptConfigController = 0
+         # Disable item "Log"
+         TYPO3\CMS\Belog\Module\BackendLogModuleBootstrap = 0
+         # Disable item "Pagetree Overview"
+         TYPO3\CMS\Info\Controller\PageInformationController = 0
+         # Disable item "Localization Overview"
+         TYPO3\CMS\Info\Controller\TranslationStatusController = 0
+         # Disable item "Linkvalidator"
+         TYPO3\CMS\Linkvalidator\Report\LinkValidatorReport = 0
+      }
 
 
 .. index::
@@ -319,22 +320,22 @@ allowInconsistentLanguageHandling
 ---------------------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    By default, TYPO3 will not allow you to mix translated content and independent content in the page module.
-    Content elements violating this behavior will be marked in the page module and there is no UI control (yet)
-    allowing you to create independent content elements in a given language.
+   By default, TYPO3 will not allow you to mix translated content and independent content in the page module.
+   Content elements violating this behavior will be marked in the page module and there is no UI control (yet)
+   allowing you to create independent content elements in a given language.
 
-    If you want to go back to the old, inconsistent behavior, you can toggle it back on using this switch.
+   If you want to go back to the old, inconsistent behavior, you can toggle it back on using this switch.
 
 :aspect:`Example`
-    Allows to set TYPO3s page module back to inconsistent language mode
+   Allows to set TYPO3s page module back to inconsistent language mode
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_layout.allowInconsistentLanguageHandling = 1
+      mod.web_layout.allowInconsistentLanguageHandling = 1
 
 
 .. index:: BackendLayouts
@@ -343,37 +344,37 @@ BackendLayouts
 --------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    Allows to define backend layouts via Page TSconfig directly, without using database records.
+   Allows to define backend layouts via Page TSconfig directly, without using database records.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_layout.BackendLayouts {
-           exampleKey {
-               title = Example
-               icon = EXT:example_extension/Resources/Public/Images/BackendLayouts/default.gif
-               config {
-                   backend_layout {
-                       colCount = 1
-                       rowCount = 2
-                       rows {
+      mod.web_layout.BackendLayouts {
+         exampleKey {
+            title = Example
+            icon = EXT:example_extension/Resources/Public/Images/BackendLayouts/default.gif
+            config {
+               backend_layout {
+                  colCount = 1
+                  rowCount = 2
+                  rows {
+                     1 {
+                        columns {
                            1 {
-                               columns {
-                                   1 {
-                                       name = LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:colPos.I.3
-                                       colPos = 3
-                                       colspan = 1
-                                   }
-                               }
+                              name = LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:colPos.I.3
+                              colPos = 3
+                              colspan = 1
                            }
-                           2 {
-                               columns {
-                                   1 {
-                                       name = Main
+                        }
+                     }
+                     2 {
+                        columns {
+                           1 {
+                              name = Main
                                        colPos = 0
                                        colspan = 1
                                    }
@@ -394,12 +395,12 @@ defaultLanguageLabel
 --------------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Alternate label for "Default" when language labels are shown in the interface.
+   Alternate label for "Default" when language labels are shown in the interface.
 
-    Overrides the same property from :ref:`mod.SHARED <pageTsConfigSharedDefaultLanguageLabel>` if set.
+   Overrides the same property from :ref:`mod.SHARED <pageTsConfigSharedDefaultLanguageLabel>` if set.
 
 .. warning::
 
@@ -417,19 +418,19 @@ defLangBinding
 --------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If set, translations of content elements are bound to the default record in the display. This means that
-    within each column with content elements any translation found for exactly the shown default content
-    element will be shown in the language column next to.
+   If set, translations of content elements are bound to the default record in the display. This means that
+   within each column with content elements any translation found for exactly the shown default content
+   element will be shown in the language column next to.
 
-    This display mode should be used depending on how the frontend is configured to display localization.
-    The frontend must display localized pages by selecting the default content elements and for each
-    one overlay with a possible translation if found.
+   This display mode should be used depending on how the frontend is configured to display localization.
+   The frontend must display localized pages by selecting the default content elements and for each
+   one overlay with a possible translation if found.
 
 :aspect:`Default`
-    0
+   0
 
 
 .. index::
@@ -440,11 +441,11 @@ disableNewContentElementWizard
 ------------------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    Disables the fact that the new-content-element icons links to the
-    content element wizard and not directly to a blank "NEW" form.
+   Disables the fact that the new-content-element icons links to the
+   content element wizard and not directly to a blank "NEW" form.
 
 
 .. index::
@@ -455,28 +456,28 @@ hideRestrictedCols
 ------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If activated, only columns will be shown in the backend that the editor is
-    allowed to access. All columns with access restriction are hidden in that case.
+   If activated, only columns will be shown in the backend that the editor is
+   allowed to access. All columns with access restriction are hidden in that case.
 
-    By default columns with restricted access are rendered with a message
-    telling *that* the user doesn't have access. This may be useless and
-    distracting or look repelling. Instead, all columns an editor doesn't have
-    access to can be hidden:
+   By default columns with restricted access are rendered with a message
+   telling *that* the user doesn't have access. This may be useless and
+   distracting or look repelling. Instead, all columns an editor doesn't have
+   access to can be hidden:
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-        mod.web_layout.hideRestrictedCols = 1
+      mod.web_layout.hideRestrictedCols = 1
 
-    .. attention::
+   .. attention::
 
-        This setting will break your layout if you are using backend layouts.
+      This setting will break your layout if you are using backend layouts.
 
 :aspect:`Default`
-    false
+   false
 
 
 .. index::
@@ -488,22 +489,22 @@ localization.enableCopy
 -----------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 
 :aspect:`Description`
-    Enables the creation of copies of content elements into languages in the translation wizard ("free mode").
+   Enables the creation of copies of content elements into languages in the translation wizard ("free mode").
 
 :aspect:`Default`
-    1
+   1
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_layout {
-           localization.enableCopy = 0
-       }
+      mod.web_layout {
+         localization.enableCopy = 0
+      }
 
 
 .. index::
@@ -515,21 +516,21 @@ localization.enableTranslate
 ----------------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    Enables simple translations of content elements in the translation wizard ("connected mode").
+   Enables simple translations of content elements in the translation wizard ("connected mode").
 
 :aspect:`Default`
-    1
+   1
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_layout {
-           localization.enableTranslate = 0
-       }
+      mod.web_layout {
+         localization.enableTranslate = 0
+      }
 
 
 .. index::
@@ -541,38 +542,38 @@ menu.functions
 --------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    Disable elements of the "Function selector" in the document header of the module.
+   Disable elements of the "Function selector" in the document header of the module.
 
-    .. figure:: /Images/ManualScreenshots/Page/FunctionMenuPageModule.png
-        :alt: The function menu of the Page module
+   .. figure:: /Images/ManualScreenshots/Page/FunctionMenuPageModule.png
+      :alt: The function menu of the Page module
 
-    The function keys are numerical:
+   The function keys are numerical:
 
-    Columns
-        1
-    Languages
-        2
+   Columns
+      1
+   Languages
+      2
 
-    .. warning::
+   .. warning::
 
-        Blinding Function Menu items is not hardcore access control! All it
-        does is hide the possibility of accessing that module functionality
-        from the interface. It might be possible for users to hack their way
-        around it and access the functionality anyways. You should use the
-        option of blinding elements mostly to remove otherwise distracting options.
+      Blinding Function Menu items is not hardcore access control! All it
+      does is hide the possibility of accessing that module functionality
+      from the interface. It might be possible for users to hack their way
+      around it and access the functionality anyways. You should use the
+      option of blinding elements mostly to remove otherwise distracting options.
 
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       # Disables "Languages" from function menu
-       mod.web_layout.menu.functions {
-           2 = 0
-       }
+      # Disables "Languages" from function menu
+      mod.web_layout.menu.functions {
+         2 = 0
+      }
 
 
 .. index::
@@ -583,13 +584,13 @@ noCreateRecordsLink
 -------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If set, the link in the bottom of the page, "Create new record", is hidden.
+   If set, the link in the bottom of the page, "Create new record", is hidden.
 
 :aspect:`Default`
-    0
+   0
 
 
 .. index::
@@ -600,44 +601,42 @@ preview
 -------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    It is possible to render previews of your own content elements in the page module.
-    By referencing a Fluid template you can create a visual representation of your content element,
-    making it easier for an editor to understand what is going on on the page.
+   It is possible to render previews of your own content elements in the page module.
+   By referencing a Fluid template you can create a visual representation of your content element,
+   making it easier for an editor to understand what is going on on the page.
 
-    The syntax is as follows:
+   The syntax is as follows:
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_layout.tt_content.preview.[CTYPE].[list_type value] = EXT:site_mysite/Resources/Private/Templates/Preview/ExamplePlugin.html
+      mod.web_layout.tt_content.preview.[CTYPE].[list_type value] = EXT:site_mysite/Resources/Private/Templates/Preview/ExamplePlugin.html
 
-    This way you can even switch between previews for your plugins by supplying `list` as CType.
+   This way you can even switch between previews for your plugins by supplying `list` as CType.
 
-    .. note::
+   .. note::
 
-       This only works, if there is no hook registered for this content type, you may want to check this
-       section in the :guilabel:`System > Configuration` module:
+      This only works, if there is no hook registered for this content type, you may want to check this
+      section in the :guilabel:`System > Configuration` module:
 
-       .. code-block:: php
-          :caption: Search for registrations of this hook
+      .. code-block:: php
+         :caption: Search for registrations of this hook
 
-          $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']
-              ['tt_content_drawItem']['content_element_xy'];
+         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']
+            ['tt_content_drawItem']['content_element_xy'];
 
 :aspect:`Example`
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
-
-       mod.web_layout.tt_content {
-           preview.custom_ce = EXT:site_mysite/Resources/Private/Templates/Preview/CustomCe.html
-           preview.table = EXT:site_mysite/Resources/Private/Templates/Preview/Table.html
-           preview.list.tx_news = EXT:site_mysite/Resources/Private/Templates/Preview/TxNews.html
-       }
-
+      mod.web_layout.tt_content {
+         preview.custom_ce = EXT:site_mysite/Resources/Private/Templates/Preview/CustomCe.html
+         preview.table = EXT:site_mysite/Resources/Private/Templates/Preview/Table.html
+         preview.list.tx_news = EXT:site_mysite/Resources/Private/Templates/Preview/TxNews.html
+      }
 
 
 .. index::
@@ -660,32 +659,32 @@ allowedNewTables
 ----------------
 
 :aspect:`Datatype`
-    list of table names
+   list of table names
 
 :aspect:`Description`
-    If this list is set, then only tables listed here will have a link to "create new" in the page and sub pages.
-    This also affects the "Create new record" content element wizard.
+   If this list is set, then only tables listed here will have a link to "create new" in the page and sub pages.
+   This also affects the "Create new record" content element wizard.
 
-    This is the opposite of :ref:`deniedNewTables property <pageTsConfigWebListDeniedNewTables>`.
+   This is the opposite of :ref:`deniedNewTables property <pageTsConfigWebListDeniedNewTables>`.
 
-    .. note::
+   .. note::
 
-       Technically records can be created (e.g. by copying/moving), so this is not a security feature.
-       The point is to reduce the number of options for new records visually.
+      Technically records can be created (e.g. by copying/moving), so this is not a security feature.
+      The point is to reduce the number of options for new records visually.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list {
-           # Only pages and sys_category table elements will be linked to in the new record wizard
-           allowedNewTables = pages, sys_category
-       }
+      mod.web_list {
+         # Only pages and sys_category table elements will be linked to in the new record wizard
+         allowedNewTables = pages, sys_category
+      }
 
-    .. figure:: /Images/ManualScreenshots/List/PageTsModWebListAllowedNewTables.png
-        :alt: The New record screen after modifying the allowed elements
+   .. figure:: /Images/ManualScreenshots/List/PageTsModWebListAllowedNewTables.png
+      :alt: The New record screen after modifying the allowed elements
 
-        The New record screen after modifying the allowed elements
+      The New record screen after modifying the allowed elements
 
 
 .. index:: clickTitleMode
@@ -694,24 +693,24 @@ clickTitleMode
 --------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Keyword which defines what happens when a user clicks a record title in the list.
+   Keyword which defines what happens when a user clicks a record title in the list.
 
-    The following values are possible:
+   The following values are possible:
 
-    edit
-        Edits record
+   edit
+      Edits record
 
-    info
-        Shows information
+   info
+      Shows information
 
-    show
-        Shows page in the frontend
+   show
+      Shows page in the frontend
 
 :aspect:`Default`
-    edit
+   edit
 
 
 .. index::
@@ -746,7 +745,7 @@ csvQuote
 --------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
    Defines the default quoting character for CSV downloads. The value set will
@@ -770,23 +769,23 @@ deniedNewTables
 ---------------
 
 :aspect:`Datatype`
-    list of table names
+   list of table names
 
 :aspect:`Description`
-    If this list is set, then the tables listed here won't have a link to "create new record" in the page
-    and sub pages. This also affects the "Create new record" content element wizard.
+   If this list is set, then the tables listed here won't have a link to "create new record" in the page
+   and sub pages. This also affects the "Create new record" content element wizard.
 
-    This is the opposite of :ref:`allowedNewTables property <pageTsConfigWebListAllowedNewTables>`.
+   This is the opposite of :ref:`allowedNewTables property <pageTsConfigWebListAllowedNewTables>`.
 
-    If `allowedNewTables` and `deniedNewTables` contain a common subset, `deniedNewTables` takes precedence.
+   If `allowedNewTables` and `deniedNewTables` contain a common subset, `deniedNewTables` takes precedence.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list {
-           deniedNewTables = sys_category, tt_content
-       }
+      mod.web_list {
+         deniedNewTables = sys_category, tt_content
+      }
 
 
 .. index:: disableSingleTableView
@@ -795,12 +794,12 @@ disableSingleTableView
 ----------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If set, then the links on the table titles which shows a single table
-    listing will not be available - including sorting links on columns
-    titles, because these links jumps to the table-only view.
+   If set, then the links on the table titles which shows a single table
+   listing will not be available - including sorting links on columns
+   titles, because these links jumps to the table-only view.
 
 
 
@@ -810,7 +809,7 @@ displayColumnSelector
 ---------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Default`
    true
@@ -822,11 +821,11 @@ displayColumnSelector
    the listed records.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       # disable the column selector completely
-       mod.web_list.displayColumnSelector = 0
+      # disable the column selector completely
+      mod.web_list.displayColumnSelector = 0
 
 .. index::
    enableClipBoard
@@ -837,26 +836,26 @@ enableClipBoard
 ---------------
 
 :aspect:`Datatype`
-    list of keywords
+   list of keywords
 
 :aspect:`Description`
-    Determines whether the checkbox "Show clipboard" in the list module is
-    shown or hidden. If it is hidden, you can predefine it to be always
-    activated or always deactivated.
+   Determines whether the checkbox "Show clipboard" in the list module is
+   shown or hidden. If it is hidden, you can predefine it to be always
+   activated or always deactivated.
 
-    The following values are possible:
+   The following values are possible:
 
-    activated
-        The option is activated and the checkbox is hidden.
+   activated
+      The option is activated and the checkbox is hidden.
 
-    deactivated
-        The option is deactivated and the checkbox is hidden.
+   deactivated
+      The option is deactivated and the checkbox is hidden.
 
-    selectable
-        The checkbox is shown so that the option can be selected by the user.
+   selectable
+      The checkbox is shown so that the option can be selected by the user.
 
 :aspect:`Default`
-    selectable
+   selectable
 
 
 .. index::
@@ -879,12 +878,12 @@ hideTables
 ----------
 
 :aspect:`Datatype`
-    list of table names, or *
+   list of table names, or *
 
 :aspect:`Description`
-    Hide these tables in record listings (comma-separated)
+   Hide these tables in record listings (comma-separated)
 
-    If `*` is used, all tables will be hidden
+   If `*` is used, all tables will be hidden
 
 
 .. index::
@@ -896,25 +895,25 @@ hideTranslations
 ----------------
 
 :aspect:`Datatype`
-    list of table names, or *
+   list of table names, or *
 
 :aspect:`Description`
-    For tables in this list all their translated records in additional website languages will be hidden
-    in the List module.
+   For tables in this list all their translated records in additional website languages will be hidden
+   in the List module.
 
-    Use `*` to hide all records of additional website languages in all tables or set
-    single table names as comma-separated list.
+   Use `*` to hide all records of additional website languages in all tables or set
+   single table names as comma-separated list.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list.hideTranslations = *
+      mod.web_list.hideTranslations = *
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list.hideTranslations = tt_content, tt_news
+      mod.web_list.hideTranslations = tt_content, tt_news
 
 
 .. index::
@@ -925,23 +924,23 @@ itemsLimitPerTable
 ------------------
 
 :aspect:`Datatype`
-    positive integer
+   positive integer
 
 :aspect:`Description`
-    Set the default maximum number of items to show per table.
-    The number must be between `5` and `10000`. If below or above this range,
-    the nearest valid number will be used.
+   Set the default maximum number of items to show per table.
+   The number must be between `5` and `10000`. If below or above this range,
+   the nearest valid number will be used.
 
 :aspect:`Default`
-    20
+   20
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list {
-          itemsLimitPerTable = 10
-       }
+      mod.web_list {
+         itemsLimitPerTable = 10
+      }
 
 .. index::
    itemsLimitSingleTable
@@ -951,23 +950,23 @@ itemsLimitSingleTable
 ---------------------
 
 :aspect:`Datatype`
-    positive integer
+   positive integer
 
 :aspect:`Description`
-    Set the default maximum number of items to show in single table view.
-    The number must be between `5` and `10000`. If below or above this range,
-    the nearest valid number will be used.
+   Set the default maximum number of items to show in single table view.
+   The number must be between `5` and `10000`. If below or above this range,
+   the nearest valid number will be used.
 
 :aspect:`Default`
-    100
+   100
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list {
-          itemsLimitSingleTable = 10
-       }
+      mod.web_list {
+         itemsLimitSingleTable = 10
+      }
 
 
 .. index::
@@ -978,32 +977,32 @@ listOnlyInSingleTableView
 -------------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If set, the default view will not show the single records inside a
-    table anymore, but only the available tables and the number of records
-    in these tables. The individual records will only be listed in the
-    single table view, that means when a table has been clicked. This is
-    very practical for pages containing many records from many tables!
+   If set, the default view will not show the single records inside a
+   table anymore, but only the available tables and the number of records
+   in these tables. The individual records will only be listed in the
+   single table view, that means when a table has been clicked. This is
+   very practical for pages containing many records from many tables!
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list {
-           listOnlyInSingleTableView = 1
-       }
+      mod.web_list {
+         listOnlyInSingleTableView = 1
+      }
 
-    The result will be that records from tables are only listed in the single-table mode:
+      The result will be that records from tables are only listed in the single-table mode:
 
-    .. figure:: /Images/ManualScreenshots/List/PageTsModWebListListOnlyInSingleTableView.png
-        :alt: The list module after activating the single-table mode
+   .. figure:: /Images/ManualScreenshots/List/PageTsModWebListListOnlyInSingleTableView.png
+      :alt: The list module after activating the single-table mode
 
-        The list module after activating the single-table mode
+      The list module after activating the single-table mode
 
 :aspect:`Default`
-    0
+   0
 
 
 .. index::
@@ -1014,18 +1013,18 @@ newContentElementWizard.override
 --------------------------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    If set to an extension key, then the specified module or route for creating
-    new content elements.
+   If set to an extension key, then the specified module or route for creating
+   new content elements.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.newContentElementWizard.override = my_custom_module
-       mod.newContentElementWizard.override = my_module_route
+      mod.newContentElementWizard.override = my_custom_module
+      mod.newContentElementWizard.override = my_module_route
 
 
 .. index::
@@ -1036,11 +1035,11 @@ newPageWizard.override
 ----------------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    If set to an extension key, then the specified module or route will be used for creating
-    new elements on the page.
+   If set to an extension key, then the specified module or route will be used for creating
+   new elements on the page.
 
 
 .. index::
@@ -1051,21 +1050,21 @@ noCreateRecordsLink
 -------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If set, the link "Create new record" is hidden.
+   If set, the link "Create new record" is hidden.
 
 :aspect:`Default`
-    0
+   0
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list {
-          noCreateRecordsLink = 1
-       }
+      mod.web_list {
+         noCreateRecordsLink = 1
+      }
 
 
 .. index::
@@ -1077,7 +1076,7 @@ noExportRecordsLinks
 --------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
    If set, the :guilabel:`Download` and :guilabel:`Export` buttons are hidden
@@ -1102,7 +1101,7 @@ noExportRecordsLinks
     0
 
 :aspect:`Example`
-    .. include:: /CodeSnippets/PageTSconfig/Mod/noExportRecordsLinks.rst.txt
+   .. include:: /CodeSnippets/PageTSconfig/Mod/noExportRecordsLinks.rst.txt
 
 
 .. index::
@@ -1113,13 +1112,13 @@ noViewWithDokTypes
 ------------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Hide view icon for the defined doktypes (comma-separated)
+   Hide view icon for the defined doktypes (comma-separated)
 
 :aspect:`Default`
-    254,255
+   254,255
 
 
 .. index::
@@ -1130,17 +1129,17 @@ table.[tableName].hideTable
 ------------------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If set to non-zero, the table is hidden. If it is zero, table is shown
-    even if table name is listed in "hideTables" list.
+   If set to non-zero, the table is hidden. If it is zero, table is shown
+   even if table name is listed in "hideTables" list.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list.table.tt_content.hideTable = 1
+      mod.web_list.table.tt_content.hideTable = 1
 
 
 .. index::
@@ -1151,7 +1150,7 @@ table.[tableName].displayColumnSelector
 ---------------------------------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
    If set to false, the column selector in the title row of the specified
@@ -1160,18 +1159,18 @@ table.[tableName].displayColumnSelector
 
 :aspect:`Example`
    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       # disable the column selector for tt_content
-       mod.web_list.table.tt_content.displayColumnSelector = 0
+      # disable the column selector for tt_content
+      mod.web_list.table.tt_content.displayColumnSelector = 0
 
 
    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       # Disable the column selector everywhere except for a specific table
-       mod.web_list.displayColumnSelector = 0
-       mod.web_list.table.sys_category.displayColumnSelector = 1
+      # Disable the column selector everywhere except for a specific table
+      mod.web_list.displayColumnSelector = 0
+      mod.web_list.table.sys_category.displayColumnSelector = 1
 
 
 .. index::
@@ -1182,20 +1181,20 @@ tableDisplayOrder
 -----------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    Flexible configuration of the order in which tables are displayed.
+   Flexible configuration of the order in which tables are displayed.
 
-    The keywords `before` and `after` can be used to specify an order relative to other table names.
+   The keywords `before` and `after` can be used to specify an order relative to other table names.
 
 :aspect:`Example`
-    .. code-block:: typoscript
+   .. code-block:: typoscript
 
-        mod.web_list.tableDisplayOrder.<tableName> {
-            before = <tableA>, <tableB>, ...
-            after = <tableA>, <tableB>, ...
-        }
+      mod.web_list.tableDisplayOrder.<tableName> {
+         before = <tableA>, <tableB>, ...
+         after = <tableA>, <tableB>, ...
+      }
 
 .. index::
    searchLevel.items
@@ -1205,22 +1204,22 @@ searchLevel.items
 -----------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    Sets labels for each level label in the search level select box
+   Sets labels for each level label in the search level select box
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_list.searchLevel.items {
-           -1 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.infinite
-           0 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.0
-           1 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.1
-           2 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.2
-           3 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.3
-           4 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.4
-       }
+      mod.web_list.searchLevel.items {
+         -1 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.infinite
+         0 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.0
+         1 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.1
+         2 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.2
+         3 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.3
+         4 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.4
+      }
 
 
 web_ts
@@ -1238,33 +1237,33 @@ menu.function
 -------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    Disable elements of the "Function selector" in the document header of the module. The keys for single
-    items can be found by browsing *System > Configuration > $GLOBALS['TBE_MODULES_EXT']*.
+   Disable elements of the "Function selector" in the document header of the module. The keys for single
+   items can be found by browsing *System > Configuration > $GLOBALS['TBE_MODULES_EXT']*.
 
-    .. figure:: /Images/ManualScreenshots/Template/FunctionMenuTemplateModule.png
-        :alt: The function menu of the Template module
+   .. figure:: /Images/ManualScreenshots/Template/FunctionMenuTemplateModule.png
+      :alt: The function menu of the Template module
 
-        The function menu of the Template module
+      The function menu of the Template module
 
-    .. warning::
+   .. warning::
 
-        Blinding Function Menu items is not hardcore access control! All it
-        does is hide the possibility of accessing that module functionality
-        from the interface. It might be possible for users to hack their way
-        around it and access the functionality anyways. You should use the
-        option of blinding elements mostly to remove otherwise distracting options.
+      Blinding Function Menu items is not hardcore access control! All it
+      does is hide the possibility of accessing that module functionality
+      from the interface. It might be possible for users to hack their way
+      around it and access the functionality anyways. You should use the
+      option of blinding elements mostly to remove otherwise distracting options.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       # Disable the item "Template Analyzer"
-       mod.web_ts.menu.function {
-           TYPO3\CMS\Tstemplate\Controller\TemplateAnalyzerModuleFunctionController = 0
-       }
+      # Disable the item "Template Analyzer"
+      mod.web_ts.menu.function {
+         TYPO3\CMS\Tstemplate\Controller\TemplateAnalyzerModuleFunctionController = 0
+      }
 
 
 
@@ -1289,41 +1288,41 @@ previewFrameWidths
 ------------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    Configure available presets in view module.
+   Configure available presets in view module.
 
-    <key>.label
-        Label for the preset
+   <key>.label
+      Label for the preset
 
-    <key>.type
-        Category of the preset, must be one of 'desktop', 'tablet' or 'mobile'
+   <key>.type
+      Category of the preset, must be one of 'desktop', 'tablet' or 'mobile'
 
-    <key>.width
-        Width of the preset
+   <key>.width
+      Width of the preset
 
-    <key>.height
-        Height of the preset
+   <key>.height
+      Height of the preset
 
 :aspect:`Example`
-    With this configuration a new preset '1014' with size 1027x768 will be configured with a label
-    loaded from an xlf file and the category 'desktop'.
+   With this configuration a new preset '1014' with size 1027x768 will be configured with a label
+   loaded from an xlf file and the category 'desktop'.
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_view.previewFrameWidths {
-           1024.label = LLL:EXT:viewpage/Resources/Private/Language/locallang.xlf:computer
-           1024.type = desktop
-           1024.width = 1024
-           1024.height = 768
-       }
+      mod.web_view.previewFrameWidths {
+         1024.label = LLL:EXT:viewpage/Resources/Private/Language/locallang.xlf:computer
+         1024.type = desktop
+         1024.width = 1024
+         1024.height = 768
+      }
 
-    .. figure:: /Images/ManualScreenshots/View/WebViewTSConfigPreview.png
-        :alt: Dropdown menu Width with added frame size called myPreview
+   .. figure:: /Images/ManualScreenshots/View/WebViewTSConfigPreview.png
+      :alt: Dropdown menu Width with added frame size called myPreview
 
-        Dropdown menu Width with added frame size called myPreview
+      Dropdown menu Width with added frame size called myPreview
 
 
 
@@ -1334,19 +1333,19 @@ type
 ----
 
 :aspect:`Datatype`
-    positive integer
+   positive integer
 
 :aspect:`Description`
-    Enter the value of the &type parameter passed to the webpage.
+   Enter the value of the &type parameter passed to the webpage.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.web_view {
-           # Frontend link will be something like index.php?id=123&type=1
-           type = 1
-       }
+      mod.web_view {
+         # Frontend link will be something like index.php?id=123&type=1
+         type = 1
+      }
 
 
 .. index:: Wizards
@@ -1365,104 +1364,104 @@ newContentElement.wizardItems
 -----------------------------
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
-    In the new content element wizard, content element types are grouped
-    together by type. Each such group can be configured independently. The
-    four default groups are: "common", "special", "forms" and "plugins".
+   In the new content element wizard, content element types are grouped
+   together by type. Each such group can be configured independently. The
+   four default groups are: "common", "special", "forms" and "plugins".
 
-    The configuration options below apply to any group.
+   The configuration options below apply to any group.
 
-    mod.wizards.newContentElement.wizardItems.[group].before
-        (string) Sorts [group] in front of the group given.
+   mod.wizards.newContentElement.wizardItems.[group].before
+      (string) Sorts [group] in front of the group given.
 
-    mod.wizards.newContentElement.wizardItems.[group].after
-        (string) Sorts [group] after the group given.
+   mod.wizards.newContentElement.wizardItems.[group].after
+      (string) Sorts [group] after the group given.
 
-    mod.wizards.newContentElement.wizardItems.[group].header
-        (localized string) Name of the group.
+   mod.wizards.newContentElement.wizardItems.[group].header
+      (localized string) Name of the group.
 
-    mod.wizards.newContentElement.wizardItems.[group].show
-        (string) Comma-separated list of items to show in the group. Use `*` to show all, example:
+   mod.wizards.newContentElement.wizardItems.[group].show
+      (string) Comma-separated list of items to show in the group. Use `*` to show all, example:
 
-        .. code-block:: typoscript
-           :caption: EXT:site_package/Configuration/page.tsconfig
+      .. code-block:: typoscript
+         :caption: EXT:site_package/Configuration/page.tsconfig
 
-            # Hide bulletList
-            mod.wizards.newContentElement.wizardItems.common.show := removeFromList(bullets)
-            # Only show text and textpic in common
-            mod.wizards.newContentElement.wizardItems.common.show = text,textpic
+         # Hide bulletList
+         mod.wizards.newContentElement.wizardItems.common.show := removeFromList(bullets)
+         # Only show text and textpic in common
+         mod.wizards.newContentElement.wizardItems.common.show = text,textpic
 
-    mod.wizards.newContentElement.wizardItems.[group].elements
-        (array) List of items in the group.
+   mod.wizards.newContentElement.wizardItems.[group].elements
+      (array) List of items in the group.
 
-    mod.wizards.newContentElement.wizardItems.[group].elements.[name]
-        (array) Configuration for a single item.
+   mod.wizards.newContentElement.wizardItems.[group].elements.[name]
+      (array) Configuration for a single item.
 
-    mod.wizards.newContentElement.wizardItems.[group].elements.[name].iconIdentifier
-        (string) The icon identifier of the icon you want to display.
+   mod.wizards.newContentElement.wizardItems.[group].elements.[name].iconIdentifier
+      (string) The icon identifier of the icon you want to display.
 
-    mod.wizards.newContentElement.wizardItems.[group].elements.[name].iconOverlay
-        (string) The icon identifier of the overlay icon you want to use.
+   mod.wizards.newContentElement.wizardItems.[group].elements.[name].iconOverlay
+      (string) The icon identifier of the overlay icon you want to use.
 
-    mod.wizards.newContentElement.wizardItems.[group].elements.[name].title
-        (localized string) Name of the item.
+   mod.wizards.newContentElement.wizardItems.[group].elements.[name].title
+      (localized string) Name of the item.
 
-    mod.wizards.newContentElement.wizardItems.[group].elements.[name].description
-        (localized string) Description text for the item.
+   mod.wizards.newContentElement.wizardItems.[group].elements.[name].description
+      (localized string) Description text for the item.
 
-    mod.wizards.newContentElement.wizardItems.[group].elements.[name].tt_content_defValues
-        (array) Default values for tt_content fields.
+   mod.wizards.newContentElement.wizardItems.[group].elements.[name].tt_content_defValues
+      (array) Default values for tt_content fields.
 
 :aspect:`Example`
-    .. _pageexample1:
+   .. _pageexample1:
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       # Add a new element (header) to the "common" group
-       mod.wizards.newContentElement.wizardItems.common.elements.header {
-           iconIdentifier = content-header
-           title = Header
-           description = Adds a header element only
-           tt_content_defValues {
-               CType = header
-           }
-       }
-       mod.wizards.newContentElement.wizardItems.common.show := addToList(header)
+      # Add a new element (header) to the "common" group
+      mod.wizards.newContentElement.wizardItems.common.elements.header {
+         iconIdentifier = content-header
+         title = Header
+         description = Adds a header element only
+         tt_content_defValues {
+            CType = header
+         }
+      }
+      mod.wizards.newContentElement.wizardItems.common.show := addToList(header)
 
-    .. _pageexample2:
+   .. _pageexample2:
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       # Create a new group and add a (pre-filled) element to it
-       mod.wizards.newContentElement.wizardItems.myGroup {
-           header = LLL:EXT:cms/layout/locallang.xlf:advancedFunctions
-           elements.customText {
-               iconIdentifier = content-text
-               title = Introductory text for national startpage
-               description = Use this element for all national startpages
-               tt_content_defValues {
-                   CType = text
-                   bodytext (
-                       <h2>Section Header</h2>
-                       <p class="bodytext">Lorem ipsum dolor sit amet, consectetur, sadipisci velit ...</p>
-                   )
-                   header = Section Header
-                   header_layout = 100
-               }
-           }
-       }
-       mod.wizards.newContentElement.wizardItems.myGroup.show = customText
+      # Create a new group and add a (pre-filled) element to it
+      mod.wizards.newContentElement.wizardItems.myGroup {
+         header = LLL:EXT:cms/layout/locallang.xlf:advancedFunctions
+         elements.customText {
+            iconIdentifier = content-text
+            title = Introductory text for national startpage
+            description = Use this element for all national startpages
+            tt_content_defValues {
+               CType = text
+               bodytext (
+                  <h2>Section Header</h2>
+                  <p class="bodytext">Lorem ipsum dolor sit amet, consectetur, sadipisci velit ...</p>
+               )
+               header = Section Header
+               header_layout = 100
+            }
+         }
+      }
+      mod.wizards.newContentElement.wizardItems.myGroup.show = customText
 
-    With the second example, the bottom of the new content element wizard shows:
+   With the second example, the bottom of the new content element wizard shows:
 
-    .. figure:: /Images/ManualScreenshots/List/PageTsModWizardsNewContentElementExample2.png
-        :alt: Added entry in the new content element wizard
+   .. figure:: /Images/ManualScreenshots/List/PageTsModWizardsNewContentElementExample2.png
+      :alt: Added entry in the new content element wizard
 
-        Added entry in the new content element wizard
+      Added entry in the new content element wizard
 
 
 .. index::
@@ -1474,29 +1473,29 @@ newRecord.order
 ---------------
 
 :aspect:`Datatype`
-    list of values
+   list of values
 
 :aspect:`Description`
-    Define an alternate order for the groups of records in the new records
-    wizard. Pages and content elements will always be on top, but the
-    order of other record groups can be changed.
+   Define an alternate order for the groups of records in the new records
+   wizard. Pages and content elements will always be on top, but the
+   order of other record groups can be changed.
 
-    Records are grouped by extension keys, plus the special key "system"
-    for records provided by the TYPO3 Core.
+   Records are grouped by extension keys, plus the special key "system"
+   for records provided by the TYPO3 Core.
 
 :aspect:`Example`
-    Place the tt_news group at the top (after pages and content
-    elements), other groups follow unchanged:
+   Place the tt_news group at the top (after pages and content
+   elements), other groups follow unchanged:
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.wizards.newRecord.order = tt_news
+      mod.wizards.newRecord.order = tt_news
 
-    .. figure:: /Images/ManualScreenshots/List/NewRecordWizardNewOrder.png
-        :alt: The position of News changed after modifying the New record screen
+   .. figure:: /Images/ManualScreenshots/List/NewRecordWizardNewOrder.png
+      :alt: The position of News changed after modifying the New record screen
 
-        The position of News changed after modifying the New record screen
+      The position of News changed after modifying the New record screen
 
 
 .. index::
@@ -1508,32 +1507,32 @@ newRecord.pages
 ---------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    Use the following sub-properties to show or hide the specified links.
-    Setting any of these properties to 0 will hide the corresponding link,
-    but setting to 1 will leave it visible.
+   Use the following sub-properties to show or hide the specified links.
+   Setting any of these properties to 0 will hide the corresponding link,
+   but setting to 1 will leave it visible.
 
-    show.pageAfter
-        Show or hide the link to create new pages after the selected page.
+   show.pageAfter
+      Show or hide the link to create new pages after the selected page.
 
-    show.pageInside
-        Show or hide the link to create new pages inside the selected page.
+   show.pageInside
+      Show or hide the link to create new pages inside the selected page.
 
-    show.pageSelectPosition
-        Show or hide the link to create new pages at a selected position.
+   show.pageSelectPosition
+      Show or hide the link to create new pages at a selected position.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       mod.wizards.newRecord.pages.show {
-           # Hide the "Page (inside)" link.
-           pageInside = 0
-       }
+      mod.wizards.newRecord.pages.show {
+         # Hide the "Page (inside)" link.
+         pageInside = 0
+      }
 
-    .. figure:: /Images/ManualScreenshots/List/PageTsModWizardsNewRecordHideInside.png
-        :alt: The modified New record screen without Page (inside)
+   .. figure:: /Images/ManualScreenshots/List/PageTsModWizardsNewRecordHideInside.png
+      :alt: The modified New record screen without Page (inside)
 
-        The modified new record screen without page (inside)
+      The modified new record screen without page (inside)

--- a/Documentation/PageTsconfig/TceForm.rst
+++ b/Documentation/PageTsconfig/TceForm.rst
@@ -53,46 +53,46 @@ addItems
 ========
 
 :aspect:`Datatype`
-    localized string
+   localized string
 
 :aspect:`Description`
-    Change the list of items in :ref:`TCA type=select <t3tca:columns-select>` fields. Using this property,
-    items can be added to the list. Note that the added elements might be removed if the selector represents
-    records: If the select box is a relation to another table. In that case only existing records
-    will be preserved.
+   Change the list of items in :ref:`TCA type=select <t3tca:columns-select>` fields. Using this property,
+   items can be added to the list. Note that the added elements might be removed if the selector represents
+   records: If the select box is a relation to another table. In that case only existing records
+   will be preserved.
 
-    The subkey `icon` will allow to add your own icons to new values.
+   The subkey `icon` will allow to add your own icons to new values.
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.tt_content.header_layout.addItems`
+   table level, example:
+      `TCEFORM.tt_content.header_layout.addItems`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header_layout.types.textpic.addItems`
+   table and record type level, example:
+      `TCEFORM.tt_content.header_layout.types.textpic.addItems`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.addItems`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.addItems`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
-    .. warning::
-        Do not add page types this way (using `TCEFORM.pages.doktype.addItems`), instead the proper
-        PHP API should be used to do this, see :ref:`Core APIs <t3coreapi:page-types>` for details.
+   .. warning::
+      Do not add page types this way (using `TCEFORM.pages.doktype.addItems`), instead the proper
+      PHP API should be used to do this, see :ref:`Core APIs <t3coreapi:page-types>` for details.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tt_content.header_layout {
-          # Add another header_layout option:
-          addItems.1525215969 = Another header layout
-          # Add another one with localized label and icon
-          addItems.1525216023 = LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:header_layout
-          addItems.1525216023.icon = EXT:my_ext/icon.png
-       }
+      TCEFORM.tt_content.header_layout {
+         # Add another header_layout option:
+         addItems.1525215969 = Another header layout
+         # Add another one with localized label and icon
+         addItems.1525216023 = LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:header_layout
+         addItems.1525216023.icon = EXT:my_ext/icon.png
+      }
 
-    Instead of adding files by path, icon identifiers should be used.
+      Instead of adding files by path, icon identifiers should be used.
 
 
 .. index::
@@ -102,39 +102,39 @@ altLabels
 =========
 
 :aspect:`Datatype`
-    localized string
+   localized string
 
 :aspect:`Description`
-    This property applies to :ref:`TCA type=select <t3tca:columns-select>`,
-    :ref:`TCA type=check <t3tca:columns-check>` and :ref:`TCA type=radio <t3tca:columns-radio>`.
+   This property applies to :ref:`TCA type=select <t3tca:columns-select>`,
+   :ref:`TCA type=check <t3tca:columns-check>` and :ref:`TCA type=radio <t3tca:columns-radio>`.
 
-    This property allows you to enter alternative labels for the items in the list. For a single checkbox or radio
-    button, use `default`, for multiple checkboxes and radiobuttons, use an integer for their position starting at 0.
+   This property allows you to enter alternative labels for the items in the list. For a single checkbox or radio
+   button, use `default`, for multiple checkboxes and radiobuttons, use an integer for their position starting at 0.
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level:
-        `TCEFORM.[tableName].[fieldName].altLabels`
+   table level:
+      `TCEFORM.[tableName].[fieldName].altLabels`
 
-    table and record type level:
-        `TCEFORM.[tableName].[fieldName].types.[typeName].altLabels`
+   table and record type level:
+      `TCEFORM.[tableName].[fieldName].types.[typeName].altLabels`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.altLabels`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.altLabels`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.doktype {
-           # Set a different item label
-           altLabels.1 = STANDARD Page Type
-           altLabels.254 = Folder (for various elements)
-           # Sets the default label for Recycler via "locallang":
-           altLabels.255 = LLL:EXT:my_ext/Resources/Private/Language/locallang_tca.xlf:recycler
-       }
+      TCEFORM.pages.doktype {
+         # Set a different item label
+         altLabels.1 = STANDARD Page Type
+         altLabels.254 = Folder (for various elements)
+         # Sets the default label for Recycler via "locallang":
+         altLabels.255 = LLL:EXT:my_ext/Resources/Private/Language/locallang_tca.xlf:recycler
+      }
 
    .. figure:: /Images/ManualScreenshots/List/PagesDoktypeDifferentLabels.png
       :alt: The Page types with modified labels
@@ -146,12 +146,12 @@ altLabels
       If the item has an **empty** value, the syntax is slightly different and an additional dot must be provided,
       like on this example:
 
-      .. code-block:: typoscript
-         :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-         TCEFORM.tt_content.space_before_class.altLabels.. = foo
+      TCEFORM.tt_content.space_before_class.altLabels.. = foo
 
-      Note the *double dot* after `altLabels`.
+   Note the *double dot* after `altLabels`.
 
 .. _page_tsconfig_id:
 
@@ -159,34 +159,34 @@ PAGE_TSCONFIG_ID
 ================
 
 :aspect:`Datatype`
-    integer
+   integer
 
 :aspect:`Description`
-    This option allows to provide a value for dynamic SQL-WHERE parameters. The
-    value is defined for a specific field of a table. For usage with flexform
-    fields, the entire path to a sub-field must be provided.
+   This option allows to provide a value for dynamic SQL-WHERE parameters. The
+   value is defined for a specific field of a table. For usage with flexform
+   fields, the entire path to a sub-field must be provided.
 
-    .. note::
+   .. note::
 
-       This value can be used for the TCA property :ref:`foreign_table_where <t3tca:columns-select-properties-foreign-table-where>`
-       and for the `addWhere` part of the :ref:`suggest wizard <pagetceformsuggest>`.
+      This value can be used for the TCA property :ref:`foreign_table_where <t3tca:columns-select-properties-foreign-table-where>`
+      and for the `addWhere` part of the :ref:`suggest wizard <pagetceformsuggest>`.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.PAGE_TSCONFIG_ID = 22
+      TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.PAGE_TSCONFIG_ID = 22
 
-    In this example, the value will substitute the marker in a plugin FlexForm.
+   In this example, the value will substitute the marker in a plugin FlexForm.
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tx_myext_table.myfield.PAGE_TSCONFIG_ID = 22
+      TCEFORM.tx_myext_table.myfield.PAGE_TSCONFIG_ID = 22
 
-    This example might be used for a record in an extension. It refers to a
-    table called `tx_myext_table` and the field `myfield`. Here the marker will
-    be substituted by the value `22`.
+   This example might be used for a record in an extension. It refers to a
+   table called `tx_myext_table` and the field `myfield`. Here the marker will
+   be substituted by the value `22`.
 
 
 .. _page_tsconfig_idlist:
@@ -195,27 +195,27 @@ PAGE_TSCONFIG_IDLIST
 ====================
 
 :aspect:`Datatype`
-    list of integers
+   list of integers
 
 :aspect:`Description`
-    See above.
+   See above.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.PAGE_TSCONFIG_IDLIST = 20,21,22
+      TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.PAGE_TSCONFIG_IDLIST = 20,21,22
 
-    In this example, the value will substitute the marker in a plugin FlexForm.
+   In this example, the value will substitute the marker in a plugin FlexForm.
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tx_myext_table.myfield.PAGE_TSCONFIG_IDLIST = 20,21,22
+      TCEFORM.tx_myext_table.myfield.PAGE_TSCONFIG_IDLIST = 20,21,22
 
-    This example might be used for a record in an extension. It refers to a
-    table called `tx_myext_table` and the field `myfield`. Here the marker will
-    be substituted by the list of integers.
+   This example might be used for a record in an extension. It refers to a
+   table called `tx_myext_table` and the field `myfield`. Here the marker will
+   be substituted by the list of integers.
 
 
 .. _page_tsconfig_str:
@@ -224,27 +224,27 @@ PAGE_TSCONFIG_STR
 =================
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    See above.
+   See above.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.PAGE_TSCONFIG_STR = %hello%
+      TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.PAGE_TSCONFIG_STR = %hello%
 
-    In this example, the value will substitute the marker in a plugin FlexForm.
+   In this example, the value will substitute the marker in a plugin FlexForm.
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tx_myext_table.myfield.PAGE_TSCONFIG_STR = %hello%
+      TCEFORM.tx_myext_table.myfield.PAGE_TSCONFIG_STR = %hello%
 
-    This example might be used for a record in an extension. It refers to a
-    table called `tx_myext_table` and the field `myfield`. Here the marker will
-    be substituted by the given value.
+   This example might be used for a record in an extension. It refers to a
+   table called `tx_myext_table` and the field `myfield`. Here the marker will
+   be substituted by the given value.
 
 
 .. index::
@@ -255,41 +255,41 @@ config
 ======
 
 :aspect:`Datatype`
-    string / array
+   string / array
 
 :aspect:`Description`
-    This setting allows to override TCA field configuration. This will influence configuration settings in
-    $GLOBALS['TCA'][<tableName>]['columns'][<fieldName>]['config'][<key>], see
-    :ref:`TCA reference <t3tca:columns-properties-config>` for details.
+   This setting allows to override TCA field configuration. This will influence configuration settings in
+   $GLOBALS['TCA'][<tableName>]['columns'][<fieldName>]['config'][<key>], see
+   :ref:`TCA reference <t3tca:columns-properties-config>` for details.
 
-    Not all configuration options can be overriden, the properties are restricted and depend on the
-    :ref:`field type <t3tca:columns-types>`. The array
-    :code:`typo3/sysext/backend/Classes/Form/Utility/FormEngineUtility.php->$allowOverrideMatrix`
-    within :ref:`FormEngine code <t3coreapi:FormEngine>` defines details:
+   Not all configuration options can be overriden, the properties are restricted and depend on the
+   :ref:`field type <t3tca:columns-types>`. The array
+   :code:`typo3/sysext/backend/Classes/Form/Utility/FormEngineUtility.php->$allowOverrideMatrix`
+   within :ref:`FormEngine code <t3coreapi:FormEngine>` defines details:
 
     .. code-block:: php
 
-        'input' => ['size', 'max', 'readOnly'],
-        'text' => ['cols', 'rows', 'wrap', 'max', 'readOnly'],
-        'check' => ['cols', 'readOnly'],
-        'select' => ['size', 'autoSizeMax', 'maxitems', 'minitems', 'readOnly', 'treeConfig'],
-        'group' => ['size', 'autoSizeMax', 'max_size', 'maxitems', 'minitems', 'readOnly'],
-        'inline' => ['appearance', 'behaviour', 'foreign_label', 'foreign_selector', 'foreign_unique', 'maxitems', 'minitems', 'size', 'autoSizeMax', 'symmetric_label', 'readOnly'],
-        'imageManipulation' => ['ratios', 'cropVariants']
+      'input' => ['size', 'max', 'readOnly'],
+      'text' => ['cols', 'rows', 'wrap', 'max', 'readOnly'],
+      'check' => ['cols', 'readOnly'],
+      'select' => ['size', 'autoSizeMax', 'maxitems', 'minitems', 'readOnly', 'treeConfig'],
+      'group' => ['size', 'autoSizeMax', 'max_size', 'maxitems', 'minitems', 'readOnly'],
+      'inline' => ['appearance', 'behaviour', 'foreign_label', 'foreign_selector', 'foreign_unique', 'maxitems', 'minitems', 'size', 'autoSizeMax', 'symmetric_label', 'readOnly'],
+      'imageManipulation' => ['ratios', 'cropVariants']
 
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.tt_content.header.config.max`
+   table level, example:
+      `TCEFORM.tt_content.header.config.max`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header.types.textpic.config.max`
+   table and record type level, example:
+      `TCEFORM.tt_content.header.types.textpic.config.max`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.config.max`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.config.max`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 
 .. index::
@@ -300,34 +300,34 @@ config.treeConfig
 =================
 
 :aspect:`Datatype`
-    int
+   int
 
 :aspect:`Description`
-    The `treeConfig` sub properties of :ref:`TCEFORM.config <pageTsConfigTceFormConfig>` are dedicated to the TCA config type
-    `select` with :ref:`renderType=selectTree <t3tca:columns-select-rendertype-selectTree>`. A couple of
-    :ref:`treeConfig <t3tca:columns-select-properties-treeconfig>` properties can be overriden on page TSconfig level, see their detailed description
-    in the :ref:`TCA reference <t3tca:columns-select-properties-treeconfig>`:
+   The `treeConfig` sub properties of :ref:`TCEFORM.config <pageTsConfigTceFormConfig>` are dedicated to the TCA config type
+   `select` with :ref:`renderType=selectTree <t3tca:columns-select-rendertype-selectTree>`. A couple of
+   :ref:`treeConfig <t3tca:columns-select-properties-treeconfig>` properties can be overriden on page TSconfig level, see their detailed description
+   in the :ref:`TCA reference <t3tca:columns-select-properties-treeconfig>`:
 
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       config.treeConfig.startingPoints = 1,42
-       config.treeConfig.appearance.expandAll = 1
-       config.treeConfig.appearance.maxLevels = 2
-       config.treeConfig.appearance.nonSelectableLevels = 1
+      config.treeConfig.startingPoints = 1,42
+      config.treeConfig.appearance.expandAll = 1
+      config.treeConfig.appearance.maxLevels = 2
+      config.treeConfig.appearance.nonSelectableLevels = 1
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.tt_content.myField.config.treeConfig.startingPoints`
+   table level, example:
+      `TCEFORM.tt_content.myField.config.treeConfig.startingPoints`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header.types.config.treeConfig.startingPoints`
+   table and record type level, example:
+      `TCEFORM.tt_content.header.types.config.treeConfig.startingPoints`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.config.treeConfig.startingPoints`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.config.treeConfig.startingPoints`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 
 .. index::
@@ -339,7 +339,7 @@ description
 .. include:: /Images/AutomaticScreenshots/Input1.rst.txt
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
    This property sets or overrides the TCA property
@@ -382,43 +382,43 @@ disabled
 ========
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    If set, the field is not displayed in the backend form of the record.
-    However, the field can still be set by other means. For example if
-    this property is set:
-    :typoscript:`TCEFORM.tt_content.colPos.disabled = 1` the :guilabel:`Column` field
-    will not be displayed in the content elements form. The
-    content element can still be moved to another column which internally also
-    sets the field :sql:`colPos`. Fields with the TSconfig property
-    :tsconfig:`TCEFORM.<table>.<field>.disable` therefore show the same
-    behaviour as fields of the TCA type :ref:`passthrough <t3tca:columns-passthrough>`.
+   If set, the field is not displayed in the backend form of the record.
+   However, the field can still be set by other means. For example if
+   this property is set:
+   :typoscript:`TCEFORM.tt_content.colPos.disabled = 1` the :guilabel:`Column` field
+   will not be displayed in the content elements form. The
+   content element can still be moved to another column which internally also
+   sets the field :sql:`colPos`. Fields with the TSconfig property
+   :tsconfig:`TCEFORM.<table>.<field>.disable` therefore show the same
+   behaviour as fields of the TCA type :ref:`passthrough <t3tca:columns-passthrough>`.
 
-    table level, example:
-        `TCEFORM.tt_content.header.disabled`
+   table level, example:
+      `TCEFORM.tt_content.header.disabled`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header.types.textpic.disabled`
+   table and record type level, example:
+      `TCEFORM.tt_content.header.types.textpic.disabled`
 
-    Flex form sheet level. If set, the entire tab is not rendered, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.disabled`
+   Flex form sheet level. If set, the entire tab is not rendered, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.disabled`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.disabled`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.disabled`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.title {
-           # The title field of the pages table is not editable
-           disabled = 1
-       }
+      TCEFORM.pages.title {
+         # The title field of the pages table is not editable
+         disabled = 1
+      }
 
 
 .. index::
@@ -429,48 +429,48 @@ disableNoMatchingValueElement
 =============================
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    This property applies only to items in :ref:`TCA type=select <t3tca:columns-select>` fields.
-    If a selector box value is not available among the options in the box, the default behavior
-    of TYPO3 is to preserve the value and to show a label which warns about this special state:
+   This property applies only to items in :ref:`TCA type=select <t3tca:columns-select>` fields.
+   If a selector box value is not available among the options in the box, the default behavior
+   of TYPO3 is to preserve the value and to show a label which warns about this special state:
 
-    .. figure:: /Images/ManualScreenshots/List/SelectInvalidValue.png
-        :alt: A missing selector box value is indicated by a warning message
+   .. figure:: /Images/ManualScreenshots/List/SelectInvalidValue.png
+      :alt: A missing selector box value is indicated by a warning message
 
-        A missing selector box value is indicated by a warning message
+      A missing selector box value is indicated by a warning message
 
-    If disableNoMatchingValueElement is set, the element "INVALID VALUE" will not be added to the list.
+   If disableNoMatchingValueElement is set, the element "INVALID VALUE" will not be added to the list.
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.tt_content.header_layout.disableNoMatchingValueElement`
+   table level, example:
+      `TCEFORM.tt_content.header_layout.disableNoMatchingValueElement`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header_layout.types.textpic.disableNoMatchingValueElement`
+   table and record type level, example:
+      `TCEFORM.tt_content.header_layout.types.textpic.disableNoMatchingValueElement`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.disableNoMatchingValueElement`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.disableNoMatchingValueElement`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.doktype {
-           # "INVALID VALUE ..." label will never show up
-           disableNoMatchingValueElement = 1
-       }
+      TCEFORM.pages.doktype {
+         # "INVALID VALUE ..." label will never show up
+         disableNoMatchingValueElement = 1
+      }
 
-    Now the selector box will default to the first element in the selector box:
+   Now the selector box will default to the first element in the selector box:
 
-    .. figure:: /Images/ManualScreenshots/List/SelectNoInvalidValue.png
-        :alt: Instead of show a warning message the system choose the first element in the selector box
+   .. figure:: /Images/ManualScreenshots/List/SelectNoInvalidValue.png
+      :alt: Instead of show a warning message the system choose the first element in the selector box
 
-        Instead of show a warning message the system choose the first element in the selector box
+      Instead of show a warning message the system choose the first element in the selector box
 
 
 .. index::
@@ -481,7 +481,7 @@ fileFolderConfig
 ================
 
 :aspect:`Datatype`
-    array
+   array
 
 :aspect:`Description`
    The special :ref:`fileFolder configuration options
@@ -501,9 +501,9 @@ fileFolderConfig
       :caption: EXT:site_package/Configuration/page.tsconfig
 
       fileFolderConfig {
-        folder = 'EXT:styleguide/Resources/Public/Icons'
-        allowedExtensions = 'svg'
-        depth = 1
+         folder = 'EXT:styleguide/Resources/Public/Icons'
+         allowedExtensions = 'svg'
+         depth = 1
       }
 
    This property is available for various levels:
@@ -528,25 +528,25 @@ itemsProcFunc
 =============
 
 :aspect:`Datatype`
-    custom
+   custom
 
 :aspect:`Description`
-    This property applies only to items in :ref:`TCA type=select <t3tca:columns-select>` fields. The properties of
-    this key is passed on to the :ref:`itemsProcFunc <t3tca:columns-select-properties-itemsprocfunc>` in the
-    parameter array by the key "TSconfig".
+   This property applies only to items in :ref:`TCA type=select <t3tca:columns-select>` fields. The properties of
+   this key is passed on to the :ref:`itemsProcFunc <t3tca:columns-select-properties-itemsprocfunc>` in the
+   parameter array by the key "TSconfig".
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level:
-        `TCEFORM.[tableName].[fieldName].itemsProcFunc`
+   table level:
+      `TCEFORM.[tableName].[fieldName].itemsProcFunc`
 
-    table and record type level:
-        `TCEFORM.[tableName].[fieldName].types.[typeName].itemsProcFunc`
+   table and record type level:
+      `TCEFORM.[tableName].[fieldName].types.[typeName].itemsProcFunc`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.itemsProcFunc`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.itemsProcFunc`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 
 .. index::
@@ -556,33 +556,33 @@ keepItems
 =========
 
 :aspect:`Datatype`
-    list of values
+   list of values
 
 :aspect:`Description`
-    Change the list of items in :ref:`TCA type=select <t3tca:columns-select>` fields. Using this property,
-    all items except those defined here are removed.
+   Change the list of items in :ref:`TCA type=select <t3tca:columns-select>` fields. Using this property,
+   all items except those defined here are removed.
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.tt_content.header_layout.keepItems`
+   table level, example:
+      `TCEFORM.tt_content.header_layout.keepItems`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header_layout.types.textpic.keepItems`
+   table and record type level, example:
+      `TCEFORM.tt_content.header_layout.types.textpic.keepItems`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.keepItems`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.keepItems`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
     .. code-block:: typoscript
        :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.doktype {
-           # Show only standard and "Spacer" page types
-           keepItems = 1, 199
-       }
+      TCEFORM.pages.doktype {
+         # Show only standard and "Spacer" page types
+         keepItems = 1, 199
+      }
 
 
 .. index::
@@ -592,36 +592,36 @@ label
 =====
 
 :aspect:`Datatype`
-    localized string
+   localized string
 
 :aspect:`Description`
-    This allows you to enter alternative labels for any field. The value can be a `LLL:` reference
-    to a localization file, the system will then look up the selected backend user language and tries
-    to fetch the localized string if available. However, it is also possible to override these by
-    appending the language key and hard setting a value, for example `label.de = Neuer Feldname`.
+   This allows you to enter alternative labels for any field. The value can be a `LLL:` reference
+   to a localization file, the system will then look up the selected backend user language and tries
+   to fetch the localized string if available. However, it is also possible to override these by
+   appending the language key and hard setting a value, for example `label.de = Neuer Feldname`.
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.[tableName].[fieldName].label`
+   table level, example:
+      `TCEFORM.[tableName].[fieldName].label`
 
-    table and record type level, example:
-        `TCEFORM.[tableName].[fieldName].types.[typeName].label`
+   table and record type level, example:
+      `TCEFORM.[tableName].[fieldName].types.[typeName].label`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.label`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.label`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.title {
-           label = LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:table.column
-           label.default = New Label
-           label.de = Neuer Feldname
-       }
+      TCEFORM.pages.title {
+         label = LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:table.column
+         label.default = New Label
+         label.de = Neuer Feldname
+      }
 
 
 .. index::
@@ -631,41 +631,41 @@ noMatchingValue_label
 =====================
 
 :aspect:`Datatype`
-    localized string
+   localized string
 
 :aspect:`Description`
-    This property applies only to items in :ref:`TCA type=select <t3tca:columns-select>` fields, it allows defining
-    a different label of the :ref:`noMatchingValue <pageFormEngineDisableNoMatchingElement>` element.
+   This property applies only to items in :ref:`TCA type=select <t3tca:columns-select>` fields, it allows defining
+   a different label of the :ref:`noMatchingValue <pageFormEngineDisableNoMatchingElement>` element.
 
-    It is possible to use the placeholder `%s` to insert the value. If the property is set to empty,
-    the label will be blank.
+   It is possible to use the placeholder `%s` to insert the value. If the property is set to empty,
+   the label will be blank.
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.tt_content.header_layout.noMatchingValue_label`
+   table level, example:
+      `TCEFORM.tt_content.header_layout.noMatchingValue_label`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header_layout.types.textpic.noMatchingValue_label`
+   table and record type level, example:
+      `TCEFORM.tt_content.header_layout.types.textpic.noMatchingValue_label`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.noMatchingValue_label`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.noMatchingValue_label`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.doktype {
-           # Different "INVALID VALUE ..." label:
-           noMatchingValue_label = VALUE "%s" was not available!
-       }
+      TCEFORM.pages.doktype {
+         # Different "INVALID VALUE ..." label:
+         noMatchingValue_label = VALUE "%s" was not available!
+      }
 
-    .. figure:: /Images/ManualScreenshots/List/SelectInvalidValueDifferentLabel.png
-        :alt:  An invalid selector box value is indicated by a warning message
+   .. figure:: /Images/ManualScreenshots/List/SelectInvalidValueDifferentLabel.png
+      :alt:  An invalid selector box value is indicated by a warning message
 
-        An invalid selector box value is indicated by a warning message
+      An invalid selector box value is indicated by a warning message
 
 
 .. index::
@@ -675,33 +675,33 @@ removeItems
 ===========
 
 :aspect:`Datatype`
-    list of values
+   list of values
 
 :aspect:`Description`
-    Change the list of items in :ref:`TCA type=select <t3tca:columns-select>` fields. Using this property,
-    single items can be removed, leaving all others.
+   Change the list of items in :ref:`TCA type=select <t3tca:columns-select>` fields. Using this property,
+   single items can be removed, leaving all others.
 
-    This property is available for various levels:
+   This property is available for various levels:
 
-    table level, example:
-        `TCEFORM.tt_content.header_layout.removeItems`
+   table level, example:
+      `TCEFORM.tt_content.header_layout.removeItems`
 
-    table and record type level, example:
-        `TCEFORM.tt_content.header_layout.types.textpic.removeItems`
+   table and record type level, example:
+      `TCEFORM.tt_content.header_layout.types.textpic.removeItems`
 
-    Flex form field level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.removeItems`
+   Flex form field level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.myField.removeItems`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.doktype {
-           # Remove "Recycler" and "Spacer" page types
-           removeItems = 199, 255
-       }
+      TCEFORM.pages.doktype {
+         # Remove "Recycler" and "Spacer" page types
+         removeItems = 199, 255
+      }
 
 .. index::
    FlexForm; Sheet description
@@ -710,15 +710,15 @@ sheetDescription
 ================
 
 :aspect:`Datatype`
-    localized string
+   localized string
 
 :aspect:`Description`
-    Specifies a description for the sheet shown in the FlexForm.
+   Specifies a description for the sheet shown in the FlexForm.
 
-    This property is only available on flex form sheet level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.sheetDescription`
+   This property is only available on flex form sheet level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.sheetDescription`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 
 .. index::
@@ -728,15 +728,15 @@ sheetShortDescr
 ===============
 
 :aspect:`Datatype`
-    localized string
+   localized string
 
 :aspect:`Description`
-    Specifies a short description of the sheet used as link title in the tab-menu.
+   Specifies a short description of the sheet used as link title in the tab-menu.
 
-    This property is only available on flex form sheet level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.sheetShortDescription`
+   This property is only available on flex form sheet level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.sheetShortDescription`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 .. index::
    FlexForm; Sheet title
@@ -745,24 +745,24 @@ sheetTitle
 ==========
 
 :aspect:`Datatype`
-    localized string
+   localized string
 
 :aspect:`Description`
-    Set the title of the sheet / tab in a FlexForm configuration.
+   Set the title of the sheet / tab in a FlexForm configuration.
 
-    This property is only available on flex form sheet level, example:
-        `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.sheetTitle`
+   This property is only available on flex form sheet level, example:
+      `TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF.sheetTitle`
 
-        Where `sDEF` is the sheet name.
+      Where `sDEF` is the sheet name.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF {
-           # Rename the first tab of the FlexForm plug-in configuration
-           sheetTitle = LLL:my_ext/Resource/Private/Language/locallang.xlf:tt_content.pi_flexform.my_ext_pi1.sDEF
-       }
+      TCEFORM.tt_content.pi_flexform.my_ext_pi1.sDEF {
+         # Rename the first tab of the FlexForm plug-in configuration
+         sheetTitle = LLL:my_ext/Resource/Private/Language/locallang.xlf:tt_content.pi_flexform.my_ext_pi1.sDEF
+      }
 
 
 .. index::
@@ -777,30 +777,30 @@ Configuration of the suggest wizard that is available and often enabled
 for :ref:`TCA type=group <t3tca:columns-group>` fields.
 
 .. figure:: /Images/ManualScreenshots/List/TcaTypeGroupSuggest.png
-    :alt: A configured suggest wizard
+   :alt: A configured suggest wizard
 
-    A configured suggest wizard
+   A configured suggest wizard
 
 The properties listed below are available on various levels. A more specific setting overrides
 a less specific one:
 
 Configuration of all suggest wizards in all tables for all target query tables:
-    `TCEFORM.suggest.default`
+   `TCEFORM.suggest.default`
 
 Configuration of all suggest wizards in all tables looking up records from a specific target table:
-    `TCEFORM.suggest.[queryTable]`
+   `TCEFORM.suggest.[queryTable]`
 
 Configuration of one suggest wizard field in one table for all target query tables:
-    `TCEFORM.[tableName].[fieldName].suggest.default`
+   `TCEFORM.[tableName].[fieldName].suggest.default`
 
 Configuration of one suggest wizard field in one table for a specific target query table:
-    `TCEFORM.[tableName].[fieldName].suggest.[queryTable]`
+   `TCEFORM.[tableName].[fieldName].suggest.[queryTable]`
 
 Configuration of one suggest wizard field in a flex form field of one table for all target query tables:
-    `TCEFORM.[tableName].[fieldName].[dataStructureKey].[sheetName].[flexFieldName].suggest.default`
+   `TCEFORM.[tableName].[fieldName].[dataStructureKey].[sheetName].[flexFieldName].suggest.default`
 
 Configuration of one suggest wizard field in a flex form field of one table for a specific target query table:
-    `TCEFORM.[tableName].[fieldName].[dataStructureKey].[sheetName].[flexFieldName].suggest.[queryTable]`
+   `TCEFORM.[tableName].[fieldName].[dataStructureKey].[sheetName].[flexFieldName].suggest.[queryTable]`
 
 
 
@@ -811,12 +811,12 @@ additionalSearchFields
 ----------------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Comma-separated list of fields the suggest wizard should also search in. By default the wizard looks only in the
-    fields listed in the :ref:`label <t3tca:ctrl-reference-label>` and :ref:`label_alt <t3tca:ctrl-reference-label-alt>`
-    of TCA :ref:`ctrl properties <t3tca:ctrl-reference>`.
+   Comma-separated list of fields the suggest wizard should also search in. By default the wizard looks only in the
+   fields listed in the :ref:`label <t3tca:ctrl-reference-label>` and :ref:`label_alt <t3tca:ctrl-reference-label-alt>`
+   of TCA :ref:`ctrl properties <t3tca:ctrl-reference>`.
 
 
 .. index::
@@ -826,26 +826,26 @@ addWhere
 --------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Additional WHERE clause (with AND at the beginning).
+   Additional WHERE clause (with AND at the beginning).
 
-    Markers possible for replacement:
+   Markers possible for replacement:
 
-    * ###THIS_UID###
-    * ###CURRENT_PID###
-    * :ref:`###PAGE_TSCONFIG_ID### <page_tsconfig_id>`
-    * :ref:`###PAGE_TSCONFIG_IDLIST### <page_tsconfig_idlist>`
-    * :ref:`###PAGE_TSCONFIG_STR### <page_tsconfig_str>`
+   *  ###THIS_UID###
+   *  ###CURRENT_PID###
+   *  :ref:`###PAGE_TSCONFIG_ID### <page_tsconfig_id>`
+   *  :ref:`###PAGE_TSCONFIG_IDLIST### <page_tsconfig_idlist>`
+   *  :ref:`###PAGE_TSCONFIG_STR### <page_tsconfig_str>`
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.storage_pid.suggest.default {
-           addWhere = AND pages.pid=###PAGE_TSCONFIG_ID###
-       }
+      TCEFORM.pages.storage_pid.suggest.default {
+         addWhere = AND pages.pid=###PAGE_TSCONFIG_ID###
+      }
 
 .. index::
    Suggest wizard; CSS class
@@ -854,20 +854,20 @@ cssClass
 --------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Add a CSS class to every list item of the result list.
+   Add a CSS class to every list item of the result list.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.suggest.pages {
-           # Configure all suggest wizards which list records from table "pages"
-           # to add the CSS class "pages" to every list item of the result list.
-           cssClass = pages
-       }
+      TCEFORM.suggest.pages {
+         # Configure all suggest wizards which list records from table "pages"
+         # to add the CSS class "pages" to every list item of the result list.
+         cssClass = pages
+      }
 
 
 .. index::
@@ -877,18 +877,18 @@ hide
 ----
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    Hide the suggest field. Works only for single fields.
+   Hide the suggest field. Works only for single fields.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.storage_pid.suggest.default {
-           hide = 1
-       }
+      TCEFORM.pages.storage_pid.suggest.default {
+         hide = 1
+      }
 
 
 .. index::
@@ -898,18 +898,18 @@ maxPathTitleLength
 ------------------
 
 :aspect:`Datatype`
-    positive integer
+   positive integer
 
 :aspect:`Description`
-    Maximum number of characters to display when a path element is too long.
+   Maximum number of characters to display when a path element is too long.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.suggest.default {
-           maxPathTitleLength = 30
-       }
+      TCEFORM.suggest.default {
+         maxPathTitleLength = 30
+      }
 
 .. index::
    Suggest wizard; Characters min
@@ -918,21 +918,21 @@ minimumCharacters
 -----------------
 
 :aspect:`Datatype`
-    positive integer
+   positive integer
 
 :aspect:`Description`
-    Minimum number of characters needed to start the search. Works only for single fields.
+   Minimum number of characters needed to start the search. Works only for single fields.
 
 :aspect:`Default`
-    2
+   2
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.storage_pid.suggest.default {
-           minimumCharacters = 3
-       }
+      TCEFORM.pages.storage_pid.suggest.default {
+         minimumCharacters = 3
+      }
 
 
 .. index::
@@ -942,19 +942,19 @@ pidDepth
 --------
 
 :aspect:`Datatype`
-    positive integer
+   positive integer
 
 :aspect:`Description`
-    Expand pidList by this number of levels. Only has an effect, if pidList has a value.
+   Expand pidList by this number of levels. Only has an effect, if pidList has a value.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.suggest.default {
-           pidList = 6,7
-           pidDepth = 4
-       }
+      TCEFORM.suggest.default {
+         pidList = 6,7
+         pidDepth = 4
+      }
 
 .. index::
    Suggest wizard; pid list
@@ -963,20 +963,20 @@ pidList
 -------
 
 :aspect:`Datatype`
-    list of values
+   list of values
 
 :aspect:`Description`
-    Limit the search to certain pages (and their subpages). When pidList is empty all pages will be included
-    in the search as long as the backend user is allowed to see them.
+   Limit the search to certain pages (and their subpages). When pidList is empty all pages will be included
+   in the search as long as the backend user is allowed to see them.
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.suggest.default {
-           # sets the pidList for a suggest fields in all tables
-           pidList = 1,2,3,45
-       }
+      TCEFORM.suggest.default {
+         # sets the pidList for a suggest fields in all tables
+         pidList = 1,2,3,45
+      }
 
 
 .. index::
@@ -986,14 +986,14 @@ receiverClass
 -------------
 
 :aspect:`Datatype`
-    PHP class name
+   PHP class name
 
 :aspect:`Description`
-    PHP class alternative receiver class - the file that holds the class should be derived
-    from :code:`\TYPO3\CMS\Backend\Form\Element\SuggestDefaultReceiver`.
+   PHP class alternative receiver class - the file that holds the class should be derived
+   from :code:`\TYPO3\CMS\Backend\Form\Element\SuggestDefaultReceiver`.
 
 :aspect:`Default`
-    :php:`\TYPO3\CMS\Backend\Form\Element\SuggestDefaultReceiver`
+   :php:`\TYPO3\CMS\Backend\Form\Element\SuggestDefaultReceiver`
 
 
 .. index::
@@ -1003,10 +1003,10 @@ renderFunc
 ----------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    User function to manipulate the displayed records in the result.
+   User function to manipulate the displayed records in the result.
 
 
 .. index::
@@ -1016,20 +1016,20 @@ searchCondition
 ---------------
 
 :aspect:`Datatype`
-    string
+   string
 
 :aspect:`Description`
-    Additional WHERE clause (no AND needed to prepend).
+   Additional WHERE clause (no AND needed to prepend).
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.storage_pid.suggest.default {
-           # Configure the suggest wizard for the field "storage_pid" in table "pages"
-           # to search only for pages with doktype=1
-           searchCondition = doktype=1
-       }
+      TCEFORM.pages.storage_pid.suggest.default {
+         # Configure the suggest wizard for the field "storage_pid" in table "pages"
+         # to search only for pages with doktype=1
+         searchCondition = doktype=1
+      }
 
 .. index::
    Suggest wizard; Search whole phrase
@@ -1038,19 +1038,19 @@ searchWholePhrase
 -----------------
 
 :aspect:`Datatype`
-    boolean
+   boolean
 
 :aspect:`Description`
-    Whether to do a `LIKE=%mystring%` (searchWholePhrase = 1) or a `LIKE=mystring%` (to do a real find as you type).
+   Whether to do a `LIKE=%mystring%` (searchWholePhrase = 1) or a `LIKE=mystring%` (to do a real find as you type).
 
 :aspect:`Default`
-    0
+   0
 
 :aspect:`Example`
-    .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/page.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/page.tsconfig
 
-       TCEFORM.pages.storage_pid.suggest.default {
-           # Configure the suggest wizard for the field "storage_pid" in table "pages" to search only for whole phrases
-          searchWholePhrase = 1
-       }
+      TCEFORM.pages.storage_pid.suggest.default {
+         # Configure the suggest wizard for the field "storage_pid" in table "pages" to search only for whole phrases
+         searchWholePhrase = 1
+      }

--- a/Documentation/UserTsconfig/Auth.rst
+++ b/Documentation/UserTsconfig/Auth.rst
@@ -8,28 +8,28 @@ auth
 The `auth` key is used for configuration of authentication services.
 
 auth.BE.redirectToURL
-    Specifies a URL to redirect to after login is performed in the backend login form. This
-    has been used in the past to redirect a backend user to the frontend to use frontend editing.
+   Specifies a URL to redirect to after login is performed in the backend login form. This
+   has been used in the past to redirect a backend user to the frontend to use frontend editing.
 
 auth.mfa.required
-    Require multi-factor authentication for a user. This overrules the global configuration
-    and can therefore also be used to unset the requirement by using `0` as value.
+   Require multi-factor authentication for a user. This overrules the global configuration
+   and can therefore also be used to unset the requirement by using `0` as value.
 
-     .. code-block:: typoscript
-        :caption: EXT:site_package/Configuration/user.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/user.tsconfig
 
-        auth.mfa.required = 1
+      auth.mfa.required = 1
 
 auth.mfa.disableProviders
-    Disable multi-factor authentication providers for the current user or group.
-    It overrules the configuration from the Backend usergroup "Access List". This
-    means, if a provider is allowed in "Access List" but disallowed with TSconfig,
-    it will be disallowed for the user or user group.
+   Disable multi-factor authentication providers for the current user or group.
+   It overrules the configuration from the Backend usergroup "Access List". This
+   means, if a provider is allowed in "Access List" but disallowed with TSconfig,
+   it will be disallowed for the user or user group.
 
-     .. code-block:: typoscript
-        :caption: EXT:site_package/Configuration/user.tsconfig
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/user.tsconfig
 
-        auth.mfa.disableProviders := addToList(totp)
+      auth.mfa.disableProviders := addToList(totp)
 
 auth.mfa.recommendedProvider
    Set a recommended multi-factor authentication provider on a per user or user group basis, which overrules


### PR DESCRIPTION
- fixed indenting
- removed extra newline after :aspect:`Example`

The indenting on the affected pages was also changed to use only
3 spaces indenting (as is defined in .editorconfig). There was
a mixture of 3 and 4 spaces indenting which makes it very difficult
to maintain the pages properly.

Since a lot of text was changed, it will probably not be possible
to backport, suggest to create a separate page for the other branches
or leave it be for now.

Related: TYPO3-Documentation/T3DocTeam#150
Related: TYPO3-Documentation/T3DocTeam#191