### PR TITLE
Add subsection properties and local toctree to page options

### DIFF
--- a/Documentation/PageTsconfig/Options.rst
+++ b/Documentation/PageTsconfig/Options.rst
@@ -8,16 +8,23 @@ options
 
 Various options for the page affecting the core at various points.
 
+Properties
+==========
+
+.. contents::
+   :depth: 2
+   :local:
+
 .. index::
    options.backendLayout
    Backend; Layout
 .. _pagebackendlayout:
 
 backendLayout
-=============
+-------------
 
 exclude
--------
+~~~~~~~
 
 :aspect:`Datatype`
     list of identifiers / uids


### PR DESCRIPTION
- table of contents for the properties is added (with the directive
"content")
- and a subsection "Properties" is added

The intention is to give an overview over the available properties and
how they are nested.

Resolves: #249