### PR TITLE
Add subsection properties and local toctree to page options

### DIFF
--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -16,12 +16,20 @@ cache menu for non admin users:
 
    options.clearCache.pages = 1
 
+Properties
+==========
+
+.. contents::
+   :depth: 2
+   :local:
+
+
 .. todo:: How does this work with site configurations?
 .. index:: Localization; preview languages
 .. _useroptions-additionalPreviewLanguages:
 
 additionalPreviewLanguages
-==========================
+--------------------------
 
 :aspect:`Datatype`
    list of sys_language ids
@@ -36,7 +44,7 @@ additionalPreviewLanguages
 .. _useroptions-alertPopups:
 
 alertPopups
-===========
+-----------
 
 :aspect:`Datatype`
    bitmask
@@ -62,7 +70,7 @@ alertPopups
 .. _useroptions-bookmarkGroups:
 
 bookmarkGroups
-==============
+--------------
 
 :aspect:`Datatype`
    Array of integers/ strings
@@ -119,7 +127,7 @@ bookmarkGroups
 .. _useroptions-clearCache-all:
 
 clearCache.all
-==============
+--------------
 
 :aspect:`Datatype`
    boolean
@@ -137,7 +145,7 @@ clearCache.all
 .. _useroptions-clearCache-pages:
 
 clearCache.pages
-================
+----------------
 
 :aspect:`Datatype`
    boolean
@@ -153,7 +161,7 @@ clearCache.pages
 .. _useroptions-clipboardNumberPads:
 
 clipboardNumberPads
-===================
+-------------------
 
 :aspect:`Datatype`
    integer (0-20)
@@ -169,7 +177,7 @@ clipboardNumberPads
 .. _useroptions-contextMenu-key-disableItems:
 
 contextMenu disableItems
-========================
+------------------------
 
 :aspect:`Datatype`
    list of items
@@ -223,7 +231,7 @@ contextMenu disableItems
 .. _useroptions-createFoldersInEB:
 
 createFoldersInEB
-=================
+-----------------
 
 :aspect:`Datatype`
    boolean
@@ -237,7 +245,7 @@ createFoldersInEB
 .. _useroptions-dashboard-dashboardPresetsForNewUsers:
 
 dashboard.dashboardPresetsForNewUsers
-=====================================
+-------------------------------------
 
 :aspect:`Datatype`
    list of dashboard identifiers
@@ -259,7 +267,7 @@ dashboard.dashboardPresetsForNewUsers
 .. _useroptions-defaultUploadFolder:
 
 defaultUploadFolder
-===================
+-------------------
 
 :aspect:`Datatype`
    string
@@ -284,7 +292,7 @@ defaultUploadFolder
 .. _useroptions-disableDelete:
 
 disableDelete
-=============
+-------------
 
 :aspect:`Datatype`
    boolean
@@ -306,7 +314,7 @@ disableDelete
 .. _useroptions-dontMountAdminMounts:
 
 dontMountAdminMounts
-====================
+--------------------
 
 :aspect:`Datatype`
    boolean
@@ -323,7 +331,7 @@ dontMountAdminMounts
 .. _useroptions-enableBookmarks:
 
 enableBookmarks
-===============
+---------------
 
 :aspect:`Datatype`
    boolean
@@ -338,14 +346,14 @@ enableBookmarks
 .. index:: File list
 
 file_list
-=========
+---------
 
 
 .. index:: File list; Clipboard enable
 .. _useroptions-file_list-enableClipBoard:
 
 file_list.enableClipBoard
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    list of keywords
@@ -370,7 +378,7 @@ file_list.enableClipBoard
 .. _useroptions-file_list-displayColumnSelector:
 
 file_list.displayColumnSelector
--------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
     boolean
@@ -402,7 +410,7 @@ file_list.displayColumnSelector
 .. _useroptions-file_list-enableDisplayBigControlPanel:
 
 file_list.enableDisplayBigControlPanel
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionchanged:: 11.3
    The checkbox :guilabel:`Extended view` was removed with TYPO3 11.3.
@@ -413,7 +421,7 @@ file_list.enableDisplayBigControlPanel
 .. _useroptions-file_list-enableDisplayThumbnails:
 
 file_list.enableDisplayThumbnails
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    list of keywords
@@ -438,7 +446,7 @@ file_list.enableDisplayThumbnails
 .. _useroptions-file_list-filesPerPage:
 
 file_list.filesPerPage
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    integer
@@ -454,7 +462,7 @@ file_list.filesPerPage
 .. _useroptions-file_list-thumbnail-height:
 
 file_list.thumbnail.height
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    integer
@@ -470,7 +478,7 @@ file_list.thumbnail.height
 .. _useroptions-file_list-thumbnail-width:
 
 file_list.thumbnail.width
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    integer
@@ -486,7 +494,7 @@ file_list.thumbnail.width
 .. _useroptions-file_list-uploader-defaultaction:
 
 file_list.uploader.defaultAction
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    string
@@ -506,14 +514,14 @@ file_list.uploader.defaultAction
 .. index:: Folder tree
 
 folderTree
-==========
+----------
 
 
 .. index:: Folder tree; File mounts in element browser
 .. _useroptions-folderTree-altElementBrowserMountPoints:
 
 folderTree.altElementBrowserMountPoints
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    list of "storageUid:folderName" items
@@ -549,7 +557,7 @@ folderTree.altElementBrowserMountPoints
 .. _useroptions-folderTree-hideCreateFolder:
 
 folderTree.hideCreateFolder
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    boolean
@@ -567,7 +575,7 @@ folderTree.hideCreateFolder
 .. _useroptions-folderTree-uploadFieldsInLinkBrowser:
 
 folderTree.uploadFieldsInLinkBrowser
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    integer
@@ -583,7 +591,7 @@ folderTree.uploadFieldsInLinkBrowser
 .. _useroptions-hideModules:
 
 hideModules.[moduleGroup]
-=========================
+-------------------------
 
 :aspect:`Datatype`
    list of module groups or modules
@@ -614,7 +622,7 @@ hideModules.[moduleGroup]
 .. _useroptions-hideRecords-pages:
 
 hideRecords.pages
-=================
+-----------------
 
 :aspect:`Datatype`
    list of page ids
@@ -642,7 +650,7 @@ hideRecords.pages
 .. _useroptions-impexp-enableImportForNonAdminUser:
 
 impexp.enableImportForNonAdminUser
-==================================
+----------------------------------
 
 :aspect:`Datatype`
    boolean
@@ -659,7 +667,7 @@ impexp.enableImportForNonAdminUser
 .. _useroptions-mayNotCreateEditBookmarks:
 
 mayNotCreateEditBookmarks
-=========================
+-------------------------
 
 :aspect:`Datatype`
    boolean
@@ -674,7 +682,7 @@ mayNotCreateEditBookmarks
 .. _useroptions-noThumbsInEB:
 
 noThumbsInEB
-============
+------------
 
 :aspect:`Datatype`
    boolean
@@ -686,7 +694,7 @@ noThumbsInEB
 .. _useroptions-overridePageModule:
 
 overridePageModule
-==================
+------------------
 
 :aspect:`Datatype`
    string
@@ -710,14 +718,14 @@ overridePageModule
 .. index:: Page tree
 
 pageTree
-========
+--------
 
 
 .. index:: Page tree; Webmounts replace
 .. _useroptions-pageTree-altElementBrowserMountPoints:
 
 pageTree.altElementBrowserMountPoints
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    list of integers
@@ -743,7 +751,7 @@ pageTree.altElementBrowserMountPoints
 .. _useroptions-pageTree-altElementBrowserMountPoints-append:
 
 pageTree.altElementBrowserMountPoints.append
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    boolean
@@ -766,7 +774,7 @@ pageTree.altElementBrowserMountPoints.append
 .. _useroptions-pageTree-backgroundColor:
 
 pageTree.backgroundColor
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    string
@@ -796,7 +804,7 @@ pageTree.backgroundColor
 .. _useroptions-pageTree-doktypesToShowInNewPageDragArea:
 
 pageTree.doktypesToShowInNewPageDragArea
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    string
@@ -818,7 +826,8 @@ pageTree.doktypesToShowInNewPageDragArea
 .. _useroptions-pageTree-excludeDoktypes:
 
 pageTree.excludeDoktypes
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 :aspect:`Datatype`
    list of integers
 
@@ -836,7 +845,7 @@ pageTree.excludeDoktypes
 .. _useroptions-pageTree-showDomainNameWithTitle:
 
 pageTree.showDomainNameWithTitle
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    boolean
@@ -851,7 +860,7 @@ pageTree.showDomainNameWithTitle
 .. _useroptions-pageTree-showNavTitle:
 
 pageTree.showNavTitle
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    boolean
@@ -866,7 +875,7 @@ pageTree.showNavTitle
 .. _useroptions-pageTree-showPageIdWithTitle:
 
 pageTree.showPageIdWithTitle
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    boolean
@@ -879,7 +888,7 @@ pageTree.showPageIdWithTitle
 .. _useroptions-pageTree-showPathAboveMounts:
 
 pageTree.showPathAboveMounts
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :aspect:`Datatype`
    boolean
@@ -935,7 +944,7 @@ passwordReset
 .. _useroptions-saveClipboard:
 
 saveClipboard
-=============
+-------------
 
 :aspect:`Datatype`
    boolean
@@ -949,7 +958,7 @@ saveClipboard
 .. _useroptions-saveDocNew:
 
 saveDocNew
-==========
+----------
 
 :aspect:`Datatype`
    boolean / "top"
@@ -979,7 +988,7 @@ saveDocNew
 .. _useroptions-saveDocView:
 
 saveDocView
-===========
+-----------
 
 :aspect:`Datatype`
    boolean
@@ -998,7 +1007,7 @@ saveDocView
 .. _useroptions-showDuplicate:
 
 showDuplicate
-=============
+-------------
 
 :aspect:`Datatype`
    boolean
@@ -1017,7 +1026,7 @@ showDuplicate
 .. _useroptions-showHistory:
 
 showHistory
-===========
+-----------
 
 :aspect:`Datatype`
    boolean


### PR DESCRIPTION
Table of contents for the properties (with the directive
"contents") and a subsection "Properties" is added.

The intention is to give an overview over the available properties and
how they are nested.

Resolves: #249