### PR TITLE
[TASK] Indent code blocks correctly

### DIFF
--- a/Documentation/UsingSetting/UserTSconfig.rst
+++ b/Documentation/UsingSetting/UserTSconfig.rst
@@ -110,19 +110,19 @@ selected groups are evaluated from top to bottom.
 
 * Add in User TSconfig
 
-.. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/page.tsconfig
+  .. code-block:: typoscript
+     :caption: EXT:site_package/Configuration/page.tsconfig
 
-	page.RTE.default.showButtons = bold
+     page.RTE.default.showButtons = bold
 
 * You get the value "bold".
 
 * Add later in User TSconfig
 
-.. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/user.tsconfig
+  .. code-block:: typoscript
+     :caption: EXT:site_package/Configuration/user.tsconfig
 
-	page.RTE.default.showButtons := addToList(italic)
+     page.RTE.default.showButtons := addToList(italic)
 
 * You get the value "bold,italic".
 
@@ -139,18 +139,18 @@ configuration
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/page.tsconfig
 
-	TCAdefaults.tt_content {
-		hidden = 1
-		header = Hello!
-	}
+   TCAdefaults.tt_content {
+      hidden = 1
+      header = Hello!
+   }
 
 Then we set the following values in the TSconfig field of the specific *user*.
 
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/user.tsconfig
 
-	TCAdefaults.tt_content.header = 234
-	options.clearCache.all = 1
+   TCAdefaults.tt_content.header = 234
+   options.clearCache.all = 1
 
 This would override the default value of the header ("234") and add the
 clear cache option. The default value of the hidden field is not


### PR DESCRIPTION
Use spaces instead of tabs to avoid large indents. Additionally,
place code blocks correctly in the examples list.

Releases: main, 11.5