### PR TITLE
[BUGFIX] Adjust example for overriding and modifying values

### DIFF
--- a/Documentation/UsingSetting/PageTSconfig.rst
+++ b/Documentation/UsingSetting/PageTSconfig.rst
@@ -206,13 +206,13 @@ Default page TSconfig
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/page.tsconfig
 
-	RTE.default.showButtons = bold
+   RTE.default.proc.allowTagsOutside = hr
 
 Static page TSconfig included on the parent page
 
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/page.tsconfig
 
-	RTE.default.showButtons := addToList(italic)
+   RTE.default.proc.allowTagsOutside := addToList(blockquote)
 
-Finally you get the value "bold,italic".
+Finally you get the value "hr,blockquote".


### PR DESCRIPTION
Important: Before merging into 11.5 and 10.4 the captions of the code blocks
have to be adjusted or removed. In 11.5 the captions are already wrong.

Resolves: #269
Releases: main, 11.5, 10.4

