### PR TITLE
[TASK] Add note for removed TSconfig options (branch 11.5)

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -445,6 +445,10 @@ defLangBinding
 disableNewContentElementWizard
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. attention::
+
+   This setting will be removed in TYPO3 v12.
+
 :aspect:`Datatype`
     boolean
 
@@ -1018,6 +1022,10 @@ listOnlyInSingleTableView
 
 newContentElementWizard.override
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attention::
+
+   This setting will be removed in TYPO3 v12.
 
 :aspect:`Datatype`
     string


### PR DESCRIPTION
This patch adds notes for options that were
removed in v12. These options were not
explicitly deprecated.

- mod.web_layout.disableNewContentElementWizard
- mod.newContentElementWizard.override

Related: TYPO3-Documentation/Changelog-To-Doc#118