### PR TITLE
[TASK] Adapt hideModules to the new syntax

### DIFF
--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -607,36 +607,41 @@ folderTree.uploadFieldsInLinkBrowser
 :aspect:`Default`
    3
 
-.. index:: Modules; Hide
-.. _useroptions-hideModules:
+..  index:: Modules; Hide
+..  _useroptions-hideModules:
 
-hideModules.[moduleGroup]
--------------------------
+hideModules
+-----------
 
 :aspect:`Datatype`
-   list of module groups or modules
+    list of module groups or modules
 
 :aspect:`Description`
-   Configure which module groups or modules should be hidden from the main menu.
+    Configure which module groups or modules should be hidden from the main menu.
 
-   It is not an access restriction but makes defined modules invisible. That means in principle
-   those modules can still be accessed if the rights allow.
+    ..  important::
+        It is not an access restriction but makes defined modules invisible.
+        This means that in principle these modules can still be accessed if the
+        rights allow this.
 
-   A list of all available module groups and modules can be found in in the backend module
-   *SYSTEM -> Configuration -> $GLOBALS['TBE_MODULES'] (BE Modules)*
+    ..  hint::
+        A list of all available module groups and modules can be found in in the
+        backend module :guilabel:`System > Configuration > Backend Modules`. The
+        system extension "lowlevel" has to be available for accessing this list.
 
 :aspect:`Example`
-   .. code-block:: typoscript
-      :caption: EXT:site_package/Configuration/user.tsconfig
+    ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/user.tsconfig
 
-      # Hide module groups "file" and "help"
-      options.hideModules = file, help
+        # Hide only module groups "file" and "help"
+        options.hideModules = file, help
 
-      # Hide module "func" and "info" from the "web" group
-      options.hideModules.web := addToList(func,info)
+        # Hide additional modules "info" and "ts" from the "web" group
+        options.hideModules := addToList(web_info, web_ts)
 
-      # Hide module BELogLog from "system" group
-      options.hideModules.system = BelogLog
+        # Hide only module BeLogLog from "system" group
+        options.hideModules = system_BelogLog
+
 
 .. index:: Records; Hide on pages
 .. _useroptions-hideRecords-pages:


### PR DESCRIPTION
The module "func" is not available anymore and was substituted with "ts" in the example.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96733-RemovedSupportForModuleHandlingBasedOnTBE_MODULES.html#migration (last line at the end)

Releases: main