### PR TITLE
[Backport 11.5] [BUGFIX] Use "TsConfig" as path part (#301)

### DIFF
--- a/Documentation/UsingSetting/PageTSconfig.rst
+++ b/Documentation/UsingSetting/PageTSconfig.rst
@@ -123,7 +123,7 @@ These can be :ref:`selected in the page properties <include-static-page-tsconfig
 
    ExtensionManagementUtility::registerPageTSConfigFile(
       'extension_name',
-      'Configuration/TSconfig/Page/myPageTSconfigFile.tsconfig',
+      'Configuration/TsConfig/Page/myPageTSconfigFile.tsconfig',
       'My special config'
    );
 
@@ -139,7 +139,7 @@ the API function:
    $GLOBALS['TCA']['pages']['columns']['tsconfig_includes']['config']['items'][] =
    [
       'LLL:EXT:my_sitepackage/Resources/Private/Language/locallang_db.xlf:pages.pageTSconfig.my_ext_be_layouts'
-      'EXT:my_sitepackage/Configuration/TSconfig/Page/myPageTSconfigFile.tsconfig',
+      'EXT:my_sitepackage/Configuration/TsConfig/Page/myPageTSconfigFile.tsconfig',
    ];
 
 .. index:: pair: Page TSconfig; Enter data
@@ -164,7 +164,7 @@ page itself and all its subpages.
 .. note::
    The configuration is stored in the database and not in the file
    system. Therefore it cannot be kept under version control. This
-   strategy is not recommended. Setting Page TSconfig in the page properties
+   strategy is not recommended. Setting page TSconfig in the page properties
    directly is available for backward-compatibility reasons and for quickly trying
    out some settings in development only.
 
@@ -174,7 +174,7 @@ page itself and all its subpages.
 Verify the final configuration
 ==============================
 
-The full Page TSconfig for any given page can be viewed using the module
+The full page TSconfig for any given page can be viewed using the module
 :guilabel:`Web > Info` module, action :guilabel:`Page TSconfig`.
 
 .. figure:: /Images/ManualScreenshots/Info/TSconfigOverview.png
@@ -189,20 +189,20 @@ Overriding and modifying values
 
 Page TSconfig is loaded in the following order, the latter override the former:
 
-#. :ref:`Default Page TSconfig <pagesettingdefaultpagetsconfig>` that was
+#. :ref:`Default page TSconfig <pagesettingdefaultpagetsconfig>` that was
    set globally
-#. :ref:`Static Page TSconfig <pagesettingdefaultpagetsconfig>` that was
+#. :ref:`Static page TSconfig <pagesettingdefaultpagetsconfig>` that was
    included for a page tree.
-#. :ref:`Direct Page TSconfig <pagetsconfig-enter-data>` entered directly in
+#. :ref:`Direct page TSconfig <pagetsconfig-enter-data>` entered directly in
    the page properties.
 #. :ref:`User TSconfig overrides <userrelationshiptovaluessetinpagetsconfig>`
 
-Static and direct Page TSconfig are loaded for the page they are set on and
+Static and direct page TSconfig are loaded for the page they are set on and
 all their subpages.
 
 The TypoScript syntax to
 :ref:`modify <t3coreapi:typoscript-syntax-syntax-value-modification>` values
-can also be used for the Page TSconfig.
+can also be used for the page TSconfig.
 
 
 Example

--- a/Documentation/UsingSetting/UserTSconfig.rst
+++ b/Documentation/UsingSetting/UserTSconfig.rst
@@ -30,7 +30,7 @@ Importing the User TSconfig into a backend user or group
    .. code-block:: typoscript
       :caption: TsConfig added in the backend record of a backend user or group
 
-      @import 'EXT:my_sitepackage/Configuration/TSconfig/User/my_editor.tsconfig'
+      @import 'EXT:my_sitepackage/Configuration/TsConfig/User/my_editor.tsconfig'
 
 This will make all settings from the file available for the user. The file
 itself can be kept under version control together with your sitepackage.
@@ -66,7 +66,7 @@ like this to set a default configuration.
 	 * Adding the default User TSconfig
 	 */
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig('
-      @import "EXT:my_sitepackage/Configuration/TSconfig/User/default.tsconfig"
+      @import "EXT:my_sitepackage/Configuration/TsConfig/User/default.tsconfig"
 	');
 
 There is a global :ref:`TYPO3_CONF_VARS <t3coreapi:typo3ConfVars>` value called


### PR DESCRIPTION
See: https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/FileStructure/Configuration/TsConfig/Index.html

Releases: main, 11.5