### PR TITLE
[Bugfix] make the screenshot tool run again with composer-installer v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ ehthumbs.db
 composer.lock
 nbproject
 Thumbs.db
+var/

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "prefer-stable": true,
     "extra": {
         "typo3/cms": {
-            "app-dir": ".Build",
-            "web-dir": ".Build/public"
+            "web-dir": ".Build/public",
+            "extension-key": "t3docs-reference-tsconfig"
         }
     },
     "config": {
@@ -57,5 +57,13 @@
         "typo3/cms-viewpage": "^12.0",
         "typo3/cms-workspaces": "^12.0",
         "t3docs/examples": "dev-main"
+    },
+    "scripts": {
+        "generate:codesnippets": [
+            ".Build/vendor/bin/typo3 codesnippet:create Documentation/CodeSnippets/"
+        ],
+        "generate": [
+            "@generate:codesnippets"
+        ]
     }
 }


### PR DESCRIPTION
It was not possible to generate the EXT: paths for PHP files anymore, so I used the FQN class paths instead.

Added a shorthand composer command to generate the code snippets:

`ddev composer generate`