### PR TITLE
Remove wrong default group permission (#311)

### DIFF
--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -274,8 +274,8 @@ group
    list of strings or integer 0-31
 
 :aspect:`Description`
-   Default permissions for group members, key list: `show`, `edit`, `delete`,
-   `new`, `editcontent`.
+    Default permissions for group members, key list: `show`, `edit`, `new`,
+    `editcontent`.
 
    Alternatively, it is allowed to set an integer between 0 and 31, indicating
    which bits corresponding to the key list should be set: `show = 1`,


### PR DESCRIPTION
"delete" flag (delete pages) is not enabled by default for groups. The doc seems a bit confusing.

See: https://github.com/TYPO3/typo3/blob/10.4/typo3/sysext/core/Classes/DataHandling/PagePermissionAssembler.php#L43

Releases: main, 11.5