### PR TITLE
[TASK] Use true and false instead of 1 and 0

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -1382,7 +1382,7 @@ newContentElement.wizardItems
       (array) Default values for tt_content fields.
 
    mod.wizards.newContentElement.wizardItems.[group].elements.[name].saveAndClose
-      (boolean) If `1`, directs the user back to the :guilabel:`Page` module directly instead of showing the FormEngine. Default `0`.
+      (boolean) If `true`, directs the user back to the :guilabel:`Page` module directly instead of showing the FormEngine. Default `false`.
 
 :aspect:`Example`
    .. _pageexample1:


### PR DESCRIPTION
This aligns the documentation with the changelog.
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.3/Feature-90461-QuickCreateContentElementsViaNewContentElementWizard.html