### PR TITLE
[FEATURE] add missing linkhandler TSconfig

### DIFF
--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -181,12 +181,76 @@ disablePrependAtCopy
         Hidden page with added suffix after copying its original page
 
 
+.. index:: Link handler
+.. _pagetcemaintables-linkhandler:
+
+linkHandler
+-----------
+
+:aspect:`Datatype`
+    array of link handler configurations
+
+:aspect:`Description`
+    Contains an array of link handler configurations.
+
+    ..  attention::
+        The keys in this array
+        uniquely identify the type of link and are used in the TYPO3 link format,
+        for example `t3://record?identifier=my_content&uid=123`. Therefore the key
+        must never be changed or all existing links in the content will stop working.
+
+    :typoscript:`handler`
+        Fully qualified name of the class containing the backend link handler.
+
+    :typoscript:`configuration`
+        Configuration for the link handler, depends on the :typoscript:`handler`.
+        For :php:`TYPO3\CMS\Backend\LinkHandler\RecordLinkHandler`
+        :typoscript:`configuration.table` must be defined.
+
+    :typoscript:`scanBefore` / :typoscript:`scanAfter`
+        Define the order in which handlers are queried when determining
+        the responsible tab for editing an existing link.
+
+    :typoscript:`displayBefore` / :typoscript:`displayAfter`
+        Define the order of how the various tabs are displayed in the
+        link browser.
+
+    ..  versionchanged:: 12.0
+        Due to the integration of EXT:recordlist into EXT:backend the namespace of
+        LinkHandlers has changed from :php:`TYPO3\CMS\Recordlist\LinkHandler` to
+        :php:`TYPO3\CMS\Backend\LinkHandler`.
+        For TYPO3 v12 the moved classes are available as an alias under the old
+        namespace to allow extensions to be compatible with TYPO3 v11 and v12.
+
+:aspect:`Example`
+    The following page TSconfig display an additional tab with the `label` as
+    title in the linkbrowser. It then saves the link in the format
+    `t3://record?identifier=my_content&uid=123`. To render the link in the
+    frontend you need to define the same key in the TypoScript setup
+    :ref:`config.recordLinks <t3tsref:recordLinks>`.
+
+    ..  tip::
+        For a complete example see also the :ref:`Record link tutorial
+        in TYPO3 Explained <t3coreapi:TableRecordLinkBrowserTutorials>`.
+
+    ..  code-block:: typoscript
+        :caption: Page TSconfig definition for identifier `my_content`
+
+        TCEMAIN.linkHandler.my_content {
+            handler = TYPO3\CMS\Backend\LinkHandler\RecordLinkHandler
+            label = LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:link.customTab
+            configuration {
+                table = tx_myextension_content
+            }
+            scanBefore = page
+        }
+
+
 .. index:: Page permissions
 .. _pagetcemain-permissions-user-group:
 
 permissions
 -----------
-
 
 .. index:: Page permissions; copyFromParent
 .. _pagetcemain-permissions-copyFromParent:


### PR DESCRIPTION
This was only described in TYPO3 explained up until now, though it rightfully belongs here.

Must be manually backported to v11.5 as the namespace changed