### PR TITLE
Add deprecation note for TSFE constants

### DIFF
--- a/Documentation/PageTsconfig/Tsfe.rst
+++ b/Documentation/PageTsconfig/Tsfe.rst
@@ -8,6 +8,11 @@ TSFE
 
 Configuration options that apply to frontend configuration.
 
+.. deprecated:: 9.5
+   This option was removed in TYPO3 v10 with the breaking change
+   :doc:`ext_core:Changelog/10.0/Breaking-88564-PageTSconfigSettingTSFEconstantsRemoved`.
+
+
 constants
 ---------
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -50,7 +50,7 @@ t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minute
 
 # TYPO3 system extensions
 # ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
-# ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
+ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
 # ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
 # ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
 # ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/


### PR DESCRIPTION
Resolves: #331
Related: TYPO3-Documentation/TYPO3CMS-Reference-CoreApi#2666

-----

not in commit: This will display a deprecation note in the 9.5 version with a link to the changelog. 

Am hoping for exception to rule to no longer make changes to 9.5 branch.