### PR TITLE
Replace links to start page (:doc: => :ref:)

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -28,8 +28,8 @@ This document describes TSconfig: A TypoScript-like syntax for configuring
 details of the TYPO3 backend.
 
 In addition, you can find a quick reference guide to TypoScript templates in
-:doc:`t3ts45:Index`, a complete reference of all object types and properties of
-TypoScript in :doc:`TypoScript Reference <t3tsref:Index>` and explanations of
+:ref:`t3ts45:start`, a complete reference of all object types and properties of
+TypoScript in :ref:`TypoScript Reference <t3tsref:start>` and explanations of
 TypoScript syntax in the chapter
 ":ref:`TypoScript Syntax <t3coreapi:typoscript-syntax-start>`" of TYPO3
 Explained.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -13,7 +13,7 @@ About this document
 This document describes TSconfig and its options: A TypoScript a-like configuration
 syntax to configure details of the backend for backend users based on a user, group and page level.
 
-This document can be seen as detail below the main :doc:`Core API <t3coreapi:Index>` document.
+This document can be seen as detail below the main :ref:`Core API <t3coreapi:start>` document.
 It is too huge to be integrated into Core API directly.
 
 First parts of this document explain the concepts of TSconfig, the different places it can be
@@ -47,7 +47,7 @@ For a general look at the syntax, please read the according section of the
 :ref:`TYPO3 Core API document <t3coreapi:typoscript-syntax-start>`.
 
 Other than the basic syntax, TSconfig and frontend TypoScript have nothing in common.
-Properties outlined in the :doc:`TypoScript Reference <t3tsref:Index>` can never be
+Properties outlined in the :ref:`TypoScript Reference <t3tsref:start>` can never be
 used in TSconfig and vice versa. Frontend TypoScript and TSconfig are different
 things: TypoScript is used to steer the rendering of the frontend web site, TSconfig
 is used to configure what is displayed to a logged in backend user.

--- a/Documentation/UsingSetting/PageTSconfig.rst
+++ b/Documentation/UsingSetting/PageTSconfig.rst
@@ -10,7 +10,7 @@ Setting page TSconfig
 =====================
 
 It is recommended to always define custom page TSconfig in a project-specific
-:doc:`sitepackage <t3sitepackage:Index>` extension. This way the page TSconfig
+:ref:`sitepackage <t3sitepackage:start>` extension. This way the page TSconfig
 settings can be kept under version control.
 
 The options described below are available for setting page TSconfig in

--- a/Documentation/UsingSetting/UserTSconfig.rst
+++ b/Documentation/UsingSetting/UserTSconfig.rst
@@ -7,7 +7,7 @@ User TSconfig
 =============
 
 It is recommended to always define custom User TSconfig in a project-specific
-:doc:`sitepackage <t3sitepackage:Index>` extension. This way the User TSconfig
+:ref:`sitepackage <t3sitepackage:start>` extension. This way the User TSconfig
 settings can be kept under version control.
 
 .. index:: pair: User TSconfig; Enter data


### PR DESCRIPTION
We now use the start label again to link to start pages

Related: TYPO3-Documentation/T3DocTeam#198