### PR TITLE
[Backport 11.5] [BUGFIX] Correct anchor for mod.web_layout.tt_content.preview (#348)

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -605,7 +605,7 @@ noCreateRecordsLink
 .. index::
    preview
    Content elements; Preview definition
-   _pageweblayoutpreview
+.. _pageweblayoutpreview:
 
 preview
 ~~~~~~~


### PR DESCRIPTION
Releases: main, 11.5