### PR TITLE
[BUGFIX] Moves disableButtonForDokType configuration

### DIFF
--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -498,9 +498,9 @@ preview
        :caption: EXT:site_package/Configuration/page.tsconfig
 
        TCEMAIN.preview {
+           disableButtonForDokType = 199, 254, 255
            <table name> {
                previewPageId = 123
-               disableButtonForDokType = 199, 254, 255
                useDefaultLanguageRecord = 0
                fieldToParameterMap {
                    uid = tx_myext_pi1[showUid]


### PR DESCRIPTION
The configuration is in the wrong place. After specifying the table, the configuration has no effect.  See https://github.com/TYPO3/typo3/blob/0113c5431ba0ff48d90c13f89c636533c9c9deed/typo3/sysext/backend/Classes/Controller/PageLayoutController.php#L613