### PR TITLE
[TASK] Adjust links to sysext manuals for v12.4

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -27,7 +27,6 @@ use_opensearch       =
 
 # Official TYPO3 manuals
 h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
-# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/12.4/en-us/
 # t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
 t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/
 # t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/12.4/en-us/
@@ -47,14 +46,14 @@ t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minute
 # t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/
 
 # TYPO3 system extensions
-ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
-ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
-# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
-# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
-# ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
-# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
-# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
-# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
-# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
-# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
-# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/
+ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/12.4/en-us/
+ext_core           = https://docs.typo3.org/c/typo3/cms-core/12.4/en-us/
+# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/12.4/en-us/
+# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/12.4/en-us/
+# ext_form           = https://docs.typo3.org/c/typo3/cms-form/12.4/en-us/
+# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/12.4/en-us/
+# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/12.4/en-us/
+# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/12.4/en-us/
+# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/12.4/en-us/
+# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/12.4/en-us/
+# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/12.4/en-us/


### PR DESCRIPTION
Additionally, remove the outdated t3cheatsheets reference.

Releases: 12.4