### PR TITLE
[BUGFIX] Adjust version of used EXT:examples

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "typo3/cms-tstemplate": "^12.4",
         "typo3/cms-viewpage": "^12.4",
         "typo3/cms-workspaces": "^12.4",
-        "t3docs/examples": "dev-main",
+        "t3docs/examples": "^12.0",
         "typo3/coding-standards": "^0.7.1"
     },
     "scripts": {


### PR DESCRIPTION
This avoids composer dependency conflicts.

Releases: 12.4