### PR TITLE
[DOCS] Mention TCAdefaults do not apply to flexforms

### DIFF
--- a/Documentation/PageTsconfig/TcaDefaults.rst
+++ b/Documentation/PageTsconfig/TcaDefaults.rst
@@ -33,3 +33,7 @@ Example:
 
    # Show newly created pages by default
    TCAdefaults.pages.hidden = 0
+
+..  note::
+    `TCAdefaults` is not (yet) applied to FlexForm values. These can only be addressed via
+    actual :xml:`<default>` elements within the FlexForm DataStructure.

--- a/Documentation/PageTsconfig/TcaDefaults.rst
+++ b/Documentation/PageTsconfig/TcaDefaults.rst
@@ -35,5 +35,5 @@ Example:
    TCAdefaults.pages.hidden = 0
 
 ..  note::
-    `TCAdefaults` is not (yet) applied to FlexForm values. These can only be addressed via
+    `TCAdefaults` is not applied to :ref:`FlexForm <t3coreapi:flexforms>` values. These can only be addressed via
     actual :xml:`<default>` elements within the FlexForm DataStructure.

--- a/Documentation/PageTsconfig/TcaDefaults.rst
+++ b/Documentation/PageTsconfig/TcaDefaults.rst
@@ -36,4 +36,4 @@ Example:
 
 ..  note::
     `TCAdefaults` is not applied to :ref:`FlexForm <t3coreapi:flexforms>` values. These can only be addressed via
-    actual :xml:`<default>` elements within the FlexForm DataStructure.
+    :xml:`<default>` elements within the FlexForm data structure.


### PR DESCRIPTION
Through https://forge.typo3.org/issues/102239 I noticed that flexforms are an edge-case that could be clarified here. Open to feedback for changing the wording on it. :-)