### PR TITLE
[TASK] Link supported languages page in TYPO3 Explained

### DIFF
--- a/Documentation/UserTsconfig/Setup.rst
+++ b/Documentation/UserTsconfig/Setup.rst
@@ -150,8 +150,7 @@ lang
 
 :aspect:`Description`
     One of the language keys. For current options see
-    :file:`typo3/sysext/core/Classes/Localization/Locales.php`, for example
-    `dk`, `de`, `es` etc.
+    :ref:`t3coreapi:i18n_languages`, for example `dk`, `de`, `es` etc.
 
 
 .. index:: Records; Hide at copy


### PR DESCRIPTION
Instead of referencing to a PHP file, link to the existing page "Supported languages" in TYPO3 Explained.

Releases: main, 12.4, 11.5