### PR TITLE
Remove section Overriding FlexForm settings

### DIFF
--- a/Documentation/UsingSetting/PageTSconfig.rst
+++ b/Documentation/UsingSetting/PageTSconfig.rst
@@ -178,17 +178,6 @@ The TypoScript syntax to
 :ref:`modify <t3coreapi:typoscript-syntax-syntax-value-modification>` values
 can also be used for the page TSconfig.
 
-Overriding FlexForm settings
-============================
-
-It is possible to override some :ref:`FlexForm <t3coreapi:flexforms>` settings via TSconfig. You can find
-some examples for this in the reference section, for example on the
-:ref:`TCEFORM <tceform>` page.
-
-The syntax is similar as when overriding TCA settings, but a little different.
-
-
-
 Example
 =======
 


### PR DESCRIPTION
This section was prematurely committed and is unncessary since there is already a description in TCEFORM for overriding FlexForm settings.

Related: #406