### PR TITLE
[Backport 12.4] [CI] Use php-cs-fixer directly (#420)

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,8 +1,73 @@
 <?php
 
-$config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config
-    ->getFinder()->in(__DIR__)
-;
+declare(strict_types=1);
 
-return $config;
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+return (new Config())
+    ->setFinder(
+        (new Finder())
+            ->in(__DIR__)
+    )
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        // @todo: Switch to @PER-CS2.0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
+        '@PER-CS1.0' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'cast_spaces' => ['space' => 'none'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'declare_parentheses' => true,
+        'dir_constant' => true,
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'type_declaration_spaces' => true,
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'method_argument_space' => true,
+        'modernize_strpos' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_nullsafe_operator' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_space_around_construct' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'single_line_empty_body' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+    ]);

--- a/Build/Scripts/validateRstFiles.php
+++ b/Build/Scripts/validateRstFiles.php
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 declare(strict_types=1);
 
 /*

--- a/Documentation/UsingSetting/_PhpApi/_MyBackendController.php
+++ b/Documentation/UsingSetting/_PhpApi/_MyBackendController.php
@@ -18,6 +18,6 @@ final class MyBackendController
 
     private function getBackendUser(): BackendUserAuthentication
     {
-        return  $GLOBALS['BE_USER'];
+        return $GLOBALS['BE_USER'];
     }
 }

--- a/Documentation/UsingSetting/_PhpApi/_MyBackendLoggedInController.php
+++ b/Documentation/UsingSetting/_PhpApi/_MyBackendLoggedInController.php
@@ -18,6 +18,6 @@ final class _MyBackendLoggedInController
 
     private function getUserTsConfig(): array
     {
-        return  $GLOBALS['BE_USER']->getTSConfig();
+        return $GLOBALS['BE_USER']->getTSConfig();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "vendor-dir": ".Build/vendor"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.48",
         "t3docs/codesnippet": "dev-main",
+        "t3docs/examples": "^12.0",
         "typo3/cms-adminpanel": "^12.4",
         "typo3/cms-backend": "^12.4",
         "typo3/cms-belog": "^12.4",
@@ -57,9 +59,7 @@
         "typo3/cms-t3editor": "^12.4",
         "typo3/cms-tstemplate": "^12.4",
         "typo3/cms-viewpage": "^12.4",
-        "typo3/cms-workspaces": "^12.4",
-        "t3docs/examples": "^12.0",
-        "typo3/coding-standards": "^0.7.1"
+        "typo3/cms-workspaces": "^12.4"
     },
     "scripts": {
         "check": [


### PR DESCRIPTION
The typo3/coding-standards package isn't compatible with Symfony 7 yet. But as this is only a proxy package for php-cs-fixer defining some rules, we can use php-cs-fixer directly.

The configuration from the TYPO3 Core is used.

See: https://github.com/TYPO3/typo3/blob/main/Build/php-cs-fixer/config.php
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/786
Releases: main, 12.4