### PR TITLE
[TASK] Reference "doktype" with the corresponding chapter

### DIFF
--- a/Documentation/PageTsconfig/Mod.rst
+++ b/Documentation/PageTsconfig/Mod.rst
@@ -1083,7 +1083,8 @@ noViewWithDokTypes
    string
 
 :aspect:`Description`
-   Hide view icon for the defined doktypes (comma-separated)
+   Hide view icon for the defined :ref:`doktypes <t3coreapi:list-of-page-types>`
+   (comma-separated).
 
 :aspect:`Default`
    254,255

--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -515,7 +515,8 @@ preview
     current page will be used. If the current page is not a normal page, the root page will be chosen.
 
     The :typoscript:`disableButtonForDokType` setting allows you to disable the preview button for a given list
-    of doktypes. If none are configured, this defaults to: 199, 254, 255 (Spacer, Folder and Recycler).
+    of :ref:`doktypes <t3coreapi:list-of-page-types>`. If none are configured, this defaults to: 199, 254, 255 (Spacer,
+    Folder and Recycler).
 
     The :typoscript:`useDefaultLanguageRecord` defaults to `1` and ensures that translated records will use the
     uid of the default record for the preview link. You may disable this, if your extension can deal

--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -936,8 +936,8 @@ pageTree.doktypesToShowInNewPageDragArea
     :Default: 1,6,4,7,3,254,255,199
 
     If set, the node top panel feature can be configured by a comma-separated
-    list. Each number stands for a doctype id that should be added to the node
-    top panel.
+    list. Each number stands for a :ref:`doktype ID <t3coreapi:list-of-page-types>`
+    that should be added to the node top panel.
 
     ..  figure:: /Images/ManualScreenshots/List/PanelNormal.png
         :alt: Top panel in normal mode
@@ -962,7 +962,10 @@ pageTree.excludeDoktypes
 
     :Data type: list of integers
 
-    Excludes nodes (pages) with one of the defined doktypes from the pagetree. Can be used for example for hiding custom doktypes.
+    Excludes nodes (pages) with one of the defined
+    :ref:`doktypes <t3coreapi:list-of-page-types>` from the page tree.
+    Can be used, for example, for hiding
+    :ref:`custom doktypes <t3coreapi:page-types-example>`.
 
     Example:
 


### PR DESCRIPTION
This makes it easier for readers to get to the list of pre-defined doktypes.

Releases: main, 12.4