### PR TITLE
[BUGFIX] Remove superfluous blank character

### DIFF
--- a/Documentation/PageTsconfig/Rte.rst
+++ b/Documentation/PageTsconfig/Rte.rst
@@ -431,8 +431,7 @@ allowTags
     Tags to allow. Notice, this list is  *added* to the default list,
     which you see here:
 
-    b,i,u,a,img,br,div,center,pre,font,hr,sub,sup,p,strong,em,li,ul,ol,blo
-    ckquote,strike,span
+    b,i,u,a,img,br,div,center,pre,font,hr,sub,sup,p,strong,em,li,ul,ol,blockquote,strike,span
 
 .. index::
    RTE; Tags outside paragraphs


### PR DESCRIPTION
In the current frontend rendering, the tag `blockquote` is incorrectly output with a space `blo ckquote` due to the line break in RST format.