### PR TITLE
[TASK] Update list of allowTags

### DIFF
--- a/Documentation/PageTsconfig/Rte.rst
+++ b/Documentation/PageTsconfig/Rte.rst
@@ -431,7 +431,7 @@ allowTags
     Tags to allow. Notice, this list is  *added* to the default list,
     which you see here:
 
-    b,i,u,a,img,br,div,center,pre,font,hr,sub,sup,p,strong,em,li,ul,ol,blockquote,strike,span
+    b,i,u,a,img,br,div,center,pre,figure,figcaption,font,hr,sub,sup,p,strong,em,li,ul,ol,blockquote,strike,span,abbr,acronym,dfn
 
 .. index::
    RTE; Tags outside paragraphs


### PR DESCRIPTION
The allowTags list has changed several times in the past TYPO3 versions. I have noticed the following changes since the current documented version:

TYPO3 v8.6
```
b,i,u,a,img,br,div,center,pre,font,hr,sub,sup,p,strong,em,li,ul,ol,blockquote,strike,span
```

TYPO3 v8.7 to 10.3:
```
b,i,u,a,img,br,div,center,pre,font,hr,sub,sup,p,strong,em,li,ul,ol,blockquote,strike,span,abbr,acronym,dfn
```

TYPO3 v10.4 to main:
```
b,i,u,a,img,br,div,center,pre,figure,figcaption,font,hr,sub,sup,p,strong,em,li,ul,ol,blockquote,strike,span,abbr,acronym,dfn
```