### PR TITLE
[TASK] Remove "Disable item "Page Tsconfig" from example

### DIFF
--- a/Documentation/PageTsconfig/Mod/WebInfo.rst
+++ b/Documentation/PageTsconfig/Mod/WebInfo.rst
@@ -103,8 +103,6 @@ Example: Remove some options from the functions menu
     :caption: EXT:site_package/Configuration/page.tsconfig
 
     mod.web_info.menu.function {
-        # Disable item "Page Tsconfig"
-        TYPO3\CMS\Info\Controller\InfoPageTyposcriptConfigController = 0
         # Disable item "Log"
         TYPO3\CMS\Belog\Module\BackendLogModuleBootstrap = 0
         # Disable item "Pagetree Overview"


### PR DESCRIPTION
"Page TSconfig" is a second-level backend module since v12, so this example is outdated.

Releases: main, 12.4