### PR TITLE
[TASK] Remove caption of code snippet

### DIFF
--- a/Documentation/PageTsconfig/Mod/Shared.rst
+++ b/Documentation/PageTsconfig/Mod/Shared.rst
@@ -68,7 +68,6 @@ The example creates a basic backend layout and sets the "Left" column to be not 
     `0` (the "Content" columns as defined above):
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/page.tsconfig
 
         mod.SHARED.colPos_list = 0
 

--- a/Documentation/PageTsconfig/Mod/Shared.rst
+++ b/Documentation/PageTsconfig/Mod/Shared.rst
@@ -68,6 +68,7 @@ The example creates a basic backend layout and sets the "Left" column to be not 
     `0` (the "Content" columns as defined above):
 
     ..  code-block:: typoscript
+        :caption: Page TSconfig in the "Resources" tab of the page
 
         mod.SHARED.colPos_list = 0
 


### PR DESCRIPTION
The caption is wrong, as the example should be added to a page field according to the description and not to a file.

Releases: main, 12.4