### PR TITLE
[BUGFIX] Resolve duplicate link anchors

### DIFF
--- a/Documentation/PageTsconfig/Rte.rst
+++ b/Documentation/PageTsconfig/Rte.rst
@@ -296,7 +296,7 @@ config.contentsLanguageDirection
 ..  index::
     RTE; Server processing
     RTE; proc
-..  _rte-proc:
+..  _rte-config-proc:
 
 proc
 ----


### PR DESCRIPTION
They cause warnings since the newest version of the render-guides

Releases: main, 12.4, 11.5