### PR TITLE
[BUGFIX] Use lowercase for file_list.uploader.defaultAction

### DIFF
--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -568,13 +568,13 @@ file_list.uploader.defaultAction
     Default action for the modal that appears when during file upload a name
     collision occurs. Possible values:
 
-    :typoscript:`Cancel`
+    :typoscript:`cancel`
         Abort the action.
 
-    :typoscript:`Rename`
+    :typoscript:`rename`
         Append the file name with a numerical index.
 
-    :typoscript:`Replace`
+    :typoscript:`replace`
         Override the file with the uploaded one.
 
 


### PR DESCRIPTION
The allowed and properly named options are defined here: \TYPO3\CMS\Core\Resource\DuplicationBehavior and if not written properly, a warning is logged here: \TYPO3\CMS\Filelist\Controller\FileListController::getDefaultDuplicationBehaviourAction and TYPO3 falls back to it's default `cancel`.