### PR TITLE
[BUGFIX] Fix links to former TypoScript syntax

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -32,7 +32,7 @@ In addition, you can find
 and a complete reference of all object types and properties of
 TypoScript in the :ref:`TypoScript Reference <t3tsref:start>` and explanations of
 TypoScript syntax in the chapter
-":ref:`TypoScript Syntax <t3coreapi:typoscript-syntax-start>`" of TYPO3
+":ref:`TypoScript Syntax <t3tsref:typoscript-syntax>`" of TYPO3
 Explained.
 
 ----

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -44,7 +44,7 @@ for users and groups ("User TSconfig"). Each variant is further detailed in this
 The general "dotted notation" of `TypoScript` is re-used for Page TSconfig and
 User TSconfig, it is possible to reference values, use conditions, and so on.
 For a general look at the syntax, please read the according section of
-:ref:`TYPO3 Explained <t3coreapi:typoscript-syntax-start>`.
+:ref:`TYPO3 Explained <t3tsref:typoscript-syntax>`.
 
 Other than the basic syntax, TSconfig and frontend TypoScript have nothing in common.
 Properties outlined in the :ref:`TypoScript Reference <t3tsref:start>` can never be

--- a/Documentation/UsingSetting/Conditions.rst
+++ b/Documentation/UsingSetting/Conditions.rst
@@ -13,7 +13,7 @@ Conditions
 ==========
 
 TSconfig TypoScript conditions offer a way to conditionally change TypoScript based
-on current context. See the :ref:`TypoScript syntax condition chapter <t3coreapi:typoscript-syntax-conditions>`
+on current context. See the :ref:`TypoScript syntax condition chapter <t3tsref:typoscript-syntax-conditions>`
 for the basic syntax of conditions.
 
 It is possible to use TypoScript conditions in both user TSconfig and page TSconfig,

--- a/Documentation/UsingSetting/PageTSconfig.rst
+++ b/Documentation/UsingSetting/PageTSconfig.rst
@@ -230,7 +230,7 @@ Static and direct page TSconfig are loaded for the page they are set on and
 all their subpages.
 
 The TypoScript syntax to
-:ref:`modify <t3coreapi:typoscript-syntax-syntax-value-modification>` values
+:ref:`modify <t3tsref:typoscript-syntax-syntax-value-modification>` values
 can also be used for the page TSconfig.
 
 Example

--- a/Documentation/UsingSetting/Syntax.rst
+++ b/Documentation/UsingSetting/Syntax.rst
@@ -15,4 +15,4 @@ Please note the following differences:
 *   In TSconfig no constants are available.
 *   There are differences in the :ref:`conditions <conditions>` that can be used.
 *   The general TypoScript syntax is described in
-    :ref:`TypoScript syntax <t3coreapi:typoscript-syntax-start>`.
+    :ref:`TypoScript syntax <t3tsref:typoscript-syntax>`.

--- a/Documentation/UsingSetting/UserTSconfig.rst
+++ b/Documentation/UsingSetting/UserTSconfig.rst
@@ -112,7 +112,7 @@ Properties, which are set in the TSconfig field of a group, are valid
 for all users of that group.
 
 Values set in one group can be overridden and
-:ref:`modified <t3coreapi:typoscript-syntax-syntax-value-modification>` in the
+:ref:`modified <t3tsref:typoscript-syntax-syntax-value-modification>` in the
 same or another group. If a user is a member of multiple groups, the TSconfig
 settings are evaluated in the order in which the groups are included in the
 user account: When editing the backend user, the selected groups are evaluated
@@ -139,7 +139,7 @@ from top to bottom.
 *   You get the value "bold,italic".
 
 Finally, you can override or
-:ref:`modify <t3coreapi:typoscript-syntax-syntax-value-modification>` the
+:ref:`modify <t3tsref:typoscript-syntax-syntax-value-modification>` the
 settings from groups that your user is a member of in the user TSconfig
 field of that specific user.
 


### PR DESCRIPTION
Releases: main, 13.4, 12.4